### PR TITLE
Support for zipkin shared spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,23 @@
 
 # Jaeger Spark dependencies
 This is a Spark job that collects spans from storage, analyze links between services,
-and stores them for later presentation in the UI. Note that it is needed for the production deployment, 
-all-in-one distribution does not need this job.
+and stores them for later presentation in the UI. Note that it is needed for the production deployment.
+`all-in-one` distribution does not need this job.
 
 This job parses all traces on a given day, based on UTC. By default, it processes the current day,
 but other days can be explicitly specified.
 
-
 This repository is based on [zipkin-dependencies](https://github.com/openzipkin/zipkin-dependencies).
+
+
+## Spans from Zipkin native clients e.g. `Brave`
+This implementation currently does not **fully** support processing of spans reported from native Zipkin
+tracers. However, in the most cases it identifies links correctly. 
+
+it is problematic if a RPC span is reported as a single span e.g. containing both client and server annotations.
+For example app instrumented with `Brave` sending requests to itself.
+In this case the job does not create a link for this service. The job also assumes that timestamp
+for client spans are lower than server spans.
 
 ## Quick-start
 Spark job can be run as docker container and also as java executable:

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -16,9 +16,12 @@ package io.jaegertracing.spark.dependencies;
 import io.jaegertracing.spark.dependencies.model.Dependency;
 import io.jaegertracing.spark.dependencies.model.Span;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.spark.api.java.function.Function;
 
 /**
@@ -29,32 +32,152 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
     /**
      * Derives dependency links based on supplied spans.
      *
-     * @param spans trace
+     * @param trace trace
      * @return collection of dependency links, note that it contains duplicates
      * @throws Exception
      */
     @Override
-    public Iterable<Dependency> call(Iterable<Span> spans) throws Exception {
-        Map<Long, Span> spanMap = new HashMap<>();
-        for (Span span: spans) {
-            spanMap.put(span.getSpanId(), span);
+    public Iterable<Dependency> call(Iterable<Span> trace) throws Exception {
+        Map<Long, Set<OnlySpanIdsKey>> spanMap = new LinkedHashMap<>();
+        for (Span span: trace) {
+            Set<OnlySpanIdsKey> sharedSpans = spanMap.get(span.getSpanId());
+            if (sharedSpans == null) {
+                sharedSpans = new LinkedHashSet<>();
+                spanMap.put(span.getSpanId(), sharedSpans);
+            }
+            sharedSpans.add(new OnlySpanIdsKey(span));
         }
 
-        List<Dependency> result = new ArrayList<>();
-        for (Span span: spans) {
+        // Let's start with zipkin shared spans
+        List<Dependency> result = sharedSpanDependencies(spanMap);
+
+        for (Span span: trace) {
             if (span.getParentId() == null || span.getProcess() == null ||
                 span.getProcess().getServiceName() == null) {
                 continue;
             }
 
-            Span parent = spanMap.get(span.getParentId());
-            if (parent == null || parent.getProcess() == null ||
-                parent.getProcess().getServiceName() == null) {
+            // if current span is shared server span we don't want to create a link
+            // because the link should be for client span
+            if (existsSpanWhichStartedBefore(span, spanMap)) {
                 continue;
             }
 
-            result.add(new Dependency(parent.getProcess().getServiceName(), span.getProcess().getServiceName()));
+            Set<OnlySpanIdsKey> parents = spanMap.get(span.getParentId());
+            if (parents != null) {
+                if (parents.size() > 1) {
+                    // multiple possible parents so parent is zipkin shared span
+                    // therefore we choose the one with the greatest start time (e.g. server span)
+                    // we cannot choose client span because it's not a true parent!
+                    Span sharedParent = null;
+                    for (OnlySpanIdsKey sharedSpan: parents) {
+                        if (sharedParent == null || sharedSpan.span.getStartTime() > sharedParent.getStartTime()) {
+                            sharedParent = sharedSpan.span;
+                        }
+                    }
+                    result.add(new Dependency(sharedParent.getProcess().getServiceName(), span.getProcess().getServiceName()));
+                } else {
+                    // this is jaeger span or zipkin native (not shared!)
+                    Span parent = parents.iterator().next().span;
+                    if (parent.getProcess() == null || parent.getProcess().getServiceName() == null) {
+                        continue;
+                    }
+                    result.add(new Dependency(parent.getProcess().getServiceName(), span.getProcess().getServiceName()));
+                }
+            }
         }
         return result;
+    }
+
+    /**
+     * @param span span
+     * @param spanMap span map, key is spanId and value set of spans
+     * @return true if there is a span in the set which started before given span.
+     */
+    private boolean existsSpanWhichStartedBefore(Span span, Map<Long, Set<OnlySpanIdsKey>> spanMap) {
+        Set<OnlySpanIdsKey> sharedSpans = spanMap.get(span.getSpanId());
+        if (sharedSpans != null && sharedSpans.size() > 1) {
+            for (OnlySpanIdsKey other: sharedSpans) {
+                if (span.getStartTime() > other.span.getStartTime()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private List<Dependency> sharedSpanDependencies(Map<Long, Set<OnlySpanIdsKey>> spanMap) {
+        List<Dependency> dependencies = new ArrayList<>();
+        // create links between shared spans
+        spanMap.values().forEach(spans -> {
+            List<OnlySpanIdsKey> spanList = new ArrayList<>(spans);
+            for (int i = 0; i < spanList.size(); i++) {
+                for (int j = i + 1; j < spanList.size(); j++) {
+                    createLinkSharedSpan(spanList.get(i).span, spanList.get(j).span)
+                        .ifPresent(dependency -> dependencies.add(dependency));
+                }
+            }
+        });
+
+        return dependencies;
+    }
+
+    private Optional<Dependency> createLinkSharedSpan(Span spanA, Span spanB) {
+        // return empty if the span is not shared
+        if (!spanA.getSpanId().equals(spanB.getSpanId())) {
+            return Optional.empty();
+        }
+
+        Dependency dependency;
+        if (spanA.getStartTime() < spanB.getStartTime()) {
+            dependency = new Dependency(spanA.getProcess().getServiceName(), spanB.getProcess().getServiceName());
+        } else {
+            dependency = new Dependency(spanB.getProcess().getServiceName(), spanA.getProcess().getServiceName());
+        }
+        return Optional.of(dependency);
+    }
+
+    /**
+     * Used in Set to eliminate the same spans reported in chunks.
+     * So we compare only ids and process because of zipkin shared spans.
+     */
+    private class OnlySpanIdsKey {
+        public final Span span;
+
+        public OnlySpanIdsKey(Span span) {
+            this.span = span;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Span)) {
+                return false;
+            }
+
+            Span other = (Span) o;
+
+            if (span.getTraceId() != null ? !span.getTraceId().equals(other.getTraceId()) : other.getTraceId() != null) {
+                return false;
+            }
+            if (span.getSpanId() != null ? !span.getSpanId().equals(other.getSpanId()) : other.getSpanId() != null) {
+                return false;
+            }
+            if (span.getParentId() != null ? !span.getParentId().equals(other.getParentId()) : other.getParentId() != null) {
+                return false;
+            }
+            return span.getProcess() != null ? span.equals(other.getProcess()) : other.getProcess() == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = span.getTraceId() != null ? span.getTraceId().hashCode() : 0;
+            result = 31 * result + (span.getSpanId() != null ? span.getSpanId().hashCode() : 0);
+            result = 31 * result + (span.getParentId() != null ? span.getParentId().hashCode() : 0);
+            result = 31 * result + (span.getProcess() != null ? span.getProcess().hashCode() : 0);
+            return result;
+        }
     }
 }

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Process.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Process.java
@@ -30,4 +30,24 @@ public class Process implements Serializable {
   public void setServiceName(String serviceName) {
     this.serviceName = serviceName;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Process)) {
+      return false;
+    }
+
+    Process process = (Process) o;
+
+    return serviceName != null ? serviceName.equals(process.serviceName)
+        : process.serviceName == null;
+  }
+
+  @Override
+  public int hashCode() {
+    return serviceName != null ? serviceName.hashCode() : 0;
+  }
 }

--- a/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/TracersGenerator.java
+++ b/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/TracersGenerator.java
@@ -30,6 +30,7 @@ import io.jaegertracing.spark.dependencies.test.tree.TracingWrapper.ZipkinWrappe
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import zipkin.Span;
 import zipkin.reporter.AsyncReporter;
 import zipkin.reporter.Encoding;
@@ -131,8 +132,7 @@ public class TracersGenerator {
       .build();
 
     AsyncReporter<Span> reporter = AsyncReporter.builder(sender)
-        // TODO when using this number of Spaks in Spark != reported spans
-//        .queuedMaxSpans(100000)
+        .closeTimeout(1, TimeUnit.MILLISECONDS)
         .build();
     return new Tuple<>(Tracing.newBuilder()
         .localServiceName(serviceName)

--- a/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/tree/Node.java
+++ b/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/tree/Node.java
@@ -37,6 +37,7 @@ public class Node<T extends TracingWrapper> {
     return tracingWrapper;
   }
 
+  // TODO shouldn't be public node should be added in constructor
   public void addDescendant(Node descendant) {
     this.descendants.add(descendant);
   }

--- a/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/tree/TreeGenerator.java
+++ b/jaeger-spark-dependencies-test/src/main/java/io/jaegertracing/spark/dependencies/test/tree/TreeGenerator.java
@@ -26,7 +26,6 @@ import java.util.Random;
  */
 public class TreeGenerator<Tracer> {
 
-  private Random descendantsRandom = new Random();
   private Random tracersRandom = new Random();
   private List<TracerHolder<Tracer>> tracers;
 
@@ -47,7 +46,7 @@ public class TreeGenerator<Tracer> {
     return root;
   }
 
-  private void generateDescendants(Queue<Node> queue, int numOfNodes, int maxNumberOfDescendants) {
+  private void generateDescendants(Queue<Node> queue, int numOfNodes, final int maxNumberOfDescendants) {
     if (numOfNodes <= 0) {
       return;
     }
@@ -56,9 +55,7 @@ public class TreeGenerator<Tracer> {
     if (parent == null) {
       return;
     }
-    // +1 to assure that we generate all exact number of nodes
-    int numOfDescendants = descendantsRandom.nextInt(maxNumberOfDescendants) + 1;
-    for (int i = 0; i < numOfDescendants; i++) {
+    for (int i = 0; i < maxNumberOfDescendants; i++) {
       Node descendant = new Node(tracers.get(tracersRandom.nextInt(tracers.size())).tracingWrapper(), parent);
       queue.add(descendant);
       parent.addDescendant(descendant);


### PR DESCRIPTION
Partially implements #3 

The current implementation does not handle zipkin spans correctly, specifically:
* shared RPC
* span reported in multiple fractions (e.g.span). For instance brave can report span with just one binary annotation.

Therefore it calculates wrong counts and missing links for RPC spans. However one can still use this job when using native zipkin tracers.

This is a simple fix which does its best to determine correct links without looking into tags.
The only issue which is not covered is when RPC a span is reported in a single span (with cs,cr,sr,ss annotations). This happens only if service is sending requests to itself and tracer caches spans internally.