### PR TITLE
Use slf4j and set logging level to INFO for jaegertracing classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ STORAGE=elasticsearch ES_NODES=http://localhost:9200 java -jar jaeger-spark-de
 To build the job locally and run tests:
 ```bash
 ./mvnw clean install # if failed add SPARK_LOCAL_IP=127.0.0.1
-docker build -t jaegertracing/jaeger-spark-dependencies:latest .
+docker build -t jaegertracing/spark-dependencies:latest .
 ```
 
    [ci-img]: https://travis-ci.org/jaegertracing/spark-dependencies.svg?branch=master

--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -147,9 +147,7 @@ public final class CassandraDependenciesJob {
     long microsLower = day.toInstant().toEpochMilli() * 1000;
     long microsUpper = day.plus(Period.ofDays(1)).toInstant().toEpochMilli() * 1000 - 1;
 
-    log.info("Running Dependencies job for {}: {} ≤ Span.timestamp {}", day, microsLower,
-        microsUpper);
-
+    log.info("Running Dependencies job for {}: {} ≤ Span.timestamp {}", day, microsLower, microsUpper);
     JavaSparkContext sc = new JavaSparkContext(conf);
     try {
       JavaPairRDD<String, Iterable<Span>> traces = javaFunctions(sc)
@@ -160,6 +158,7 @@ public final class CassandraDependenciesJob {
 
       List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces);
       store(sc, dependencyLinks);
+      log.info("Done, %d dependency objects created", dependencyLinks.size());
     } finally {
       sc.stop();
     }

--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -158,7 +158,7 @@ public final class CassandraDependenciesJob {
 
       List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces);
       store(sc, dependencyLinks);
-      log.info("Done, %d dependency objects created", dependencyLinks.size());
+      log.info("Done, {} dependency objects created", dependencyLinks.size());
     } finally {
       sc.stop();
     }

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
@@ -162,7 +162,7 @@ public class ElasticsearchDependenciesJob {
 
       List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces);
       store(sc, dependencyLinks, depResource);
-      log.info("Done, %d dependency objects created", dependencyLinks.size());
+      log.info("Done, {} dependency objects created", dependencyLinks.size());
     } finally {
       sc.stop();
     }

--- a/jaeger-spark-dependencies/src/main/resources/log4j.properties
+++ b/jaeger-spark-dependencies/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@
 #
 
 # Set everything to be logged to the console
-log4j.rootCategory=INFO, console
+log4j.rootCategory=WARN, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout

--- a/jaeger-spark-dependencies/src/main/resources/log4j.properties
+++ b/jaeger-spark-dependencies/src/main/resources/log4j.properties
@@ -13,7 +13,7 @@
 #
 
 # Set everything to be logged to the console
-log4j.rootCategory=WARN, console
+log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
@@ -24,6 +24,7 @@ log4j.logger.org.spark-project.jetty=WARN
 log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.io.jaegertracing.spark=INFO
 
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL


### PR DESCRIPTION
Fixes #15 

Example output:
```
docker run  --env="STORAGE=cassandra" jaegertracing/spark-dependencies:latest | fpaste                 11:11 
17/10/10 09:11:55 INFO CassandraDependenciesJob: Running Dependencies job for 2017-10-10T00:00Z: 1507593600000000 ≤ Span.timestamp 1507679999999999
17/10/10 09:11:55 INFO SparkContext: Running Spark version 2.1.1
17/10/10 09:11:55 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
17/10/10 09:11:55 INFO SecurityManager: Changing view acls to: root
17/10/10 09:11:55 INFO SecurityManager: Changing modify acls to: root
17/10/10 09:11:55 INFO SecurityManager: Changing view acls groups to: 
17/10/10 09:11:55 INFO SecurityManager: Changing modify acls groups to: 
17/10/10 09:11:55 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(root); groups with view permissions: Set(); users  with modify permissions: Set(root); groups with modify permissions: Set()
17/10/10 09:11:56 INFO Utils: Successfully started service 'sparkDriver' on port 35969.
17/10/10 09:11:56 INFO SparkEnv: Registering MapOutputTracker
17/10/10 09:11:56 INFO SparkEnv: Registering BlockManagerMaster
17/10/10 09:11:56 INFO BlockManagerMasterEndpoint: Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information
17/10/10 09:11:56 INFO BlockManagerMasterEndpoint: BlockManagerMasterEndpoint up
17/10/10 09:11:56 INFO DiskBlockManager: Created local directory at /tmp/blockmgr-61add854-62c0-420e-a38a-30bfd980d925
17/10/10 09:11:56 INFO MemoryStore: MemoryStore started with capacity 3.9 GB
17/10/10 09:11:56 INFO SparkEnv: Registering OutputCommitCoordinator
17/10/10 09:11:56 INFO SparkContext: Added JAR /app/jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar at spark://172.17.0.2:35969/jars/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar with timestamp 1507626716216
17/10/10 09:11:56 INFO Executor: Starting executor ID driver on host localhost
17/10/10 09:11:56 INFO Utils: Successfully started service 'org.apache.spark.network.netty.NettyBlockTransferService' on port 38633.
17/10/10 09:11:56 INFO NettyBlockTransferService: Server created on 172.17.0.2:38633
17/10/10 09:11:56 INFO BlockManager: Using org.apache.spark.storage.RandomBlockReplicationPolicy for block replication policy
17/10/10 09:11:56 INFO BlockManagerMaster: Registering BlockManager BlockManagerId(driver, 172.17.0.2, 38633, None)
17/10/10 09:11:56 INFO BlockManagerMasterEndpoint: Registering block manager 172.17.0.2:38633 with 3.9 GB RAM, BlockManagerId(driver, 172.17.0.2, 38633, None)
17/10/10 09:11:56 INFO BlockManagerMaster: Registered BlockManager BlockManagerId(driver, 172.17.0.2, 38633, None)
17/10/10 09:11:56 INFO BlockManager: Initialized BlockManager: BlockManagerId(driver, 172.17.0.2, 38633, None)
17/10/10 09:11:56 INFO log: Logging initialized @1503ms
17/10/10 09:11:57 INFO Native: Could not load JNR C Library, native system calls through this library will not be available (set this logger level to DEBUG to see the full stack trace).
17/10/10 09:11:57 INFO ClockFactory: Using java.lang.System clock to generate timestamps.
17/10/10 09:11:57 INFO NettyUtil: Found Netty's native epoll transport in the classpath, using it
17/10/10 09:12:00 INFO MapOutputTrackerMasterEndpoint: MapOutputTrackerMasterEndpoint stopped!
17/10/10 09:12:00 INFO MemoryStore: MemoryStore cleared
17/10/10 09:12:00 INFO BlockManager: BlockManager stopped
17/10/10 09:12:00 INFO BlockManagerMaster: BlockManagerMaster stopped
17/10/10 09:12:00 INFO OutputCommitCoordinator$OutputCommitCoordinatorEndpoint: OutputCommitCoordinator stopped!
17/10/10 09:12:00 INFO SparkContext: Successfully stopped SparkContext
Exception in thread "main" java.io.IOException: Failed to open native connection to Cassandra at {127.0.0.1}:9042
```
