### PR TITLE
Ignore more editor debris

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.*.swp
+*.iml
+.idea
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
             <exclude>**/ElasticsearchDependenciesJob.java</exclude>
             <exclude>**/CassandraDependenciesJob.java</exclude>
             <exclude>**/CassandraContainer.java</exclude>
+            <exclude>**swp</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
Yes this can be globally configured, but tools like the license checker
need to know whats ignored too, so its best to have these in-tree so the
results are consistent for everyone.