### PR TITLE
Enable cassandra client SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY mvnw $APP_HOME
 WORKDIR $APP_HOME
 RUN ./mvnw package -Dlicense.skip=true -DskipTests && rm -rf ~/.m2
 
-CMD java -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar
+CMD java ${JAVA_OPTS} -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Cassandra is used when `STORAGE=cassandra`.
     * `CASSANDRA_LOCAL_DC`: The local DC to connect to (other nodes will be ignored)
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails
     * `CASSANDRA_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
+    * `CASSANDRA_SSL_KEYSTORE`: If set enables client authentication on SSL connections.
+    * `CASSANDRA_SSL_KEYSTORE_PASSWORD`: Password for the keystore.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Docker:
 $ docker run --env STORAGE=cassandra --env CASSANDRA_CONTACT_POINTS=host1,host2 jaegertracing/spark-dependencies
 ```
 
+Use `--env JAVA_OPTS=-Djavax.net.ssl.` to set trust store and other Java properties.
+
 As jar file:
 ```bash
 STORAGE=cassandra java -jar jaeager-spark-dependencies.jar
@@ -50,8 +52,6 @@ Cassandra is used when `STORAGE=cassandra`.
     * `CASSANDRA_LOCAL_DC`: The local DC to connect to (other nodes will be ignored)
     * `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`: Cassandra authentication. Will throw an exception on startup if authentication fails
     * `CASSANDRA_USE_SSL`: Requires `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword`, defaults to false.
-    * `CASSANDRA_SSL_KEYSTORE`: If set enables client authentication on SSL connections.
-    * `CASSANDRA_SSL_KEYSTORE_PASSWORD`: Password for the keystore.
 
 Example usage:
 

--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -78,6 +78,12 @@ public final class CassandraDependenciesJob {
           System.getProperty("javax.net.ssl.trustStorePassword", ""));
       sparkProperties.put("spark.cassandra.connection.ssl.trustStore.path",
           System.getProperty("javax.net.ssl.trustStore", ""));
+      sparkProperties.put("spark.cassandra.connection.ssl.clientAuth.enabled",
+          Utils.getEnv("CASSANDRA_SSL_KEYSTORE", "").isEmpty() ? "false" : "true");
+      sparkProperties.put("spark.cassandra.connection.ssl.keyStore.path",
+          Utils.getEnv("CASSANDRA_SSL_KEYSTORE", ""));
+      sparkProperties.put("spark.cassandra.connection.ssl.keyStore.password",
+          Utils.getEnv("CASSANDRA_SSL_KEYSTORE_PASSWORD", ""));
       sparkProperties.put("spark.cassandra.auth.username", Utils.getEnv("CASSANDRA_USERNAME", ""));
       sparkProperties.put("spark.cassandra.auth.password", Utils.getEnv("CASSANDRA_PASSWORD", ""));
     }

--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -78,12 +78,6 @@ public final class CassandraDependenciesJob {
           System.getProperty("javax.net.ssl.trustStorePassword", ""));
       sparkProperties.put("spark.cassandra.connection.ssl.trustStore.path",
           System.getProperty("javax.net.ssl.trustStore", ""));
-      sparkProperties.put("spark.cassandra.connection.ssl.clientAuth.enabled",
-          Utils.getEnv("CASSANDRA_SSL_KEYSTORE", "").isEmpty() ? "false" : "true");
-      sparkProperties.put("spark.cassandra.connection.ssl.keyStore.path",
-          Utils.getEnv("CASSANDRA_SSL_KEYSTORE", ""));
-      sparkProperties.put("spark.cassandra.connection.ssl.keyStore.password",
-          Utils.getEnv("CASSANDRA_SSL_KEYSTORE_PASSWORD", ""));
       sparkProperties.put("spark.cassandra.auth.username", Utils.getEnv("CASSANDRA_USERNAME", ""));
       sparkProperties.put("spark.cassandra.auth.password", Utils.getEnv("CASSANDRA_PASSWORD", ""));
     }


### PR DESCRIPTION
Different version of https://github.com/jaegertracing/spark-dependencies/pull/21

The original codebase contained SSL configuration via `CASSANDRA_USE_SSL`. Trust store and pass are configured via `javax.net.ssl`, but these properties weren't passed to java command in docker.


