### PR TITLE
Make ES client-node only configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Elasticsearch is used when `STORAGE=elasticsearch`.
     * `ES_USERNAME` and `ES_PASSWORD`: Elasticsearch basic authentication. Use when X-Pack security
                                        (formerly Shield) is in place. By default no username or
                                        password is provided to elasticsearch.
+    * `ES_CLIENT_NODE_ONLY`: Set to true to disable elasticsearch cluster nodes.discovery and enable nodes.client.only. 
+                             If your elasticsearch cluster's data nodes only listen on loopback ip, set this to true. 
+                             Defaults to false
 
 Example usage:
 

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
@@ -51,6 +51,7 @@ public class ElasticsearchDependenciesJob {
     String hosts = Utils.getEnv("ES_NODES", "127.0.0.1");
     String username = Utils.getEnv("ES_USERNAME", null);
     String password = Utils.getEnv("ES_PASSWORD", null);
+    Boolean clientNodeOnly = Boolean.parseBoolean(Utils.getEnv("ES_CLIENT_NODE_ONLY", "false"));
 
     final Map<String, String> sparkProperties = new LinkedHashMap<>();
 
@@ -137,6 +138,10 @@ public class ElasticsearchDependenciesJob {
     conf.set("es.nodes", builder.hosts);
     if (builder.hosts.indexOf("https") != -1) {
       conf.set("es.net.ssl", "true");
+    }
+    if (builder.clientNodeOnly) {
+      conf.set("es.nodes.discovery", "0");
+      conf.set("es.nodes.client.only", "1");
     }
     for (Map.Entry<String, String> entry : builder.sparkProperties.entrySet()) {
       conf.set(entry.getKey(), entry.getValue());


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
In es cluster mode, there are three node role(master,data,client).
Maybe the data node only listen in local loopback(127.0.0.1) ip, then run the job will cause error:
"
18/08/21 23:03:23 ERROR NetworkClient: Node [127.0.0.1:9201] failed (Connection refused: connect); selected next node [127.0.0.1:9210] 
18/08/21 23:03:27 ERROR NetworkClient: Node [127.0.0.1:9210] failed (Connection refused: connect); selected next node [10.1.11.123:9200] 
18/08/21 23:03:31 ERROR NetworkClient: Node [127.0.0.1:9201] failed (Connection refused: connect); no other nodes left - aborting... Exception in thread "main" org.elasticsearch.hadoop.rest.EsHadoopNoNodesLeftException: Connection error (check network and/or proxy settings)- all nodes failed; tried [[127.0.0.1:9201]]
"
this is cause by "es.nodes.discovery (default true)" and "es.nodes.client.only (default false)".
[in the elastic hadoop doc](https://www.elastic.co/guide/en/elasticsearch/hadoop/current/configuration.html)

## Short description of the changes
Add an configurable to set elasticsearch-hadoop conf with es client-node only and disable discovery.
