### PR TITLE
For validating of the kind of a span, use span.kind type

### DIFF
--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -99,21 +99,11 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
     }
 
     static boolean isClientSpan(Span span) {
-        for (KeyValue tag: span.getTags()) {
-            if (Tags.SPAN_KIND_CLIENT.equals(tag.getValueString())) {
-                return true;
-            }
-        }
-        return false;
+        return Tags.SPAN_KIND_CLIENT.equals(span.getTag(Tags.SPAN_KIND.getKey()));
     }
 
     static boolean isServerSpan(Span span) {
-        for (KeyValue tag: span.getTags()) {
-            if (Tags.SPAN_KIND_SERVER.equals(tag.getValueString())) {
-                return true;
-            }
-        }
-        return false;
+        return Tags.SPAN_KIND_SERVER.equals(span.getTag(Tags.SPAN_KIND.getKey()));
     }
 
     private List<Dependency> sharedSpanDependencies(Map<Long, Set<Span>> spanMap) {

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Span.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Span.java
@@ -66,6 +66,15 @@ public class Span implements Serializable {
     return tags;
   }
 
+  public String getTag(String key){
+    for (KeyValue kv : tags){
+      if (kv.getKey().equals(key)){
+        return kv.getValueString();
+      }
+    }
+    return null;
+  }
+
   public void setTags(List<KeyValue> tags) {
     this.tags = tags;
   }


### PR DESCRIPTION
Resolves : https://github.com/jaegertracing/spark-dependencies/issues/49

Currently the validation of the kind of the span is done on the following
method :

* When at least one tag has client, it is considered as a client tag
* When at least one tag has server, it is considered as a server tag

This patch verify the kind by checking span.kind tag (as defined
in opentracing specification)

Signed-off-by: Etienne Carriere <etienne.a.carriere@socgen.com>