### PR TITLE
Add in DAG the services called but not instrumented

### DIFF
--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -123,11 +123,6 @@ public final class CassandraDependenciesJob {
       return this;
     }
 
-    public Builder properties(Map<String,String> properties){
-      sparkProperties.putAll(properties);
-      return this;
-    }
-
     public CassandraDependenciesJob build() {
       return new CassandraDependenciesJob(this);
     }
@@ -159,7 +154,7 @@ public final class CassandraDependenciesJob {
     }
   }
 
-  public void run() {
+  public void run(String peerServiceTag) {
     long microsLower = day.toInstant().toEpochMilli() * 1000;
     long microsUpper = day.plus(Period.ofDays(1)).toInstant().toEpochMilli() * 1000 - 1;
 
@@ -173,7 +168,7 @@ public final class CassandraDependenciesJob {
           .mapValues(span -> (Span) span)
           .groupByKey();
 
-      List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces);
+      List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces,peerServiceTag);
       store(sc, dependencyLinks);
       log.info("Done, {} dependency objects created", dependencyLinks.size());
     } finally {

--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJob.java
@@ -123,9 +123,15 @@ public final class CassandraDependenciesJob {
       return this;
     }
 
+    public Builder properties(Map<String,String> properties){
+      sparkProperties.putAll(properties);
+      return this;
+    }
+
     public CassandraDependenciesJob build() {
       return new CassandraDependenciesJob(this);
     }
+
   }
 
   private final String keyspace;

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
@@ -120,7 +120,7 @@ public class CassandraDependenciesJobTest extends DependenciesTest {
         .day(LocalDate.now())
         .keyspace("jaeger_v1_dc1")
         .build()
-        .run();
+        .run("peer.service");
   }
 
   @Override

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkHelper.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkHelper.java
@@ -35,8 +35,8 @@ public class DependenciesSparkHelper {
    *                     spans with that traceId.
    * @return Aggregated dependency links for all traces.
    */
-  public static List<Dependency> derive(JavaPairRDD<String, Iterable<Span>> traceIdSpans) {
-    return traceIdSpans.flatMapValues(new SpansToDependencyLinks())
+  public static List<Dependency> derive(JavaPairRDD<String, Iterable<Span>> traceIdSpans,String peerServiceTag) {
+    return traceIdSpans.flatMapValues(new SpansToDependencyLinks(peerServiceTag))
         .values()
         .mapToPair(dependency -> new Tuple2<>(new Tuple2<>(dependency.getParent(), dependency.getChild()), dependency))
         .reduceByKey((v1, v2) -> new Dependency(v1.getParent(), v1.getChild(), v1.getCallCount() + v2.getCallCount()))

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -42,11 +42,16 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
      * @throws Exception
      */
 
+    public String peerServiceTag = "";
+
+    public SpansToDependencyLinks(String peerServiceTag){
+        this.peerServiceTag = peerServiceTag;
+    }
+
     @Override
     public Iterable<Dependency> call(Iterable<Span> trace) throws Exception {
         Map<Long, Set<Span>> spanMap = new LinkedHashMap<>();
         Map<Long, Set<Span>> spanChildrenMap = new LinkedHashMap<>();
-        String uninstrumentedKey = SparkEnv.get().conf().get("jaeger.uninstrumented_key","peer.service");
         for (Span span: trace) {
             // Map of children
             for (Reference ref: span.getRefs()){
@@ -101,7 +106,7 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
             }
             // We are on a leaf so we try to add a dependency for calls to components that calls remote components not instrumented
             if (spanChildrenMap.get(span.getSpanId()) == null ){
-              String targetName = span.getTag(uninstrumentedKey);
+              String targetName = span.getTag(peerServiceTag);
               if (targetName != null) {
                 result.add(new Dependency(span.getProcess().getServiceName(), targetName));
               }

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Span.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Span.java
@@ -20,6 +20,7 @@ import java.util.List;
  * @author Pavol Loffay
  */
 public class Span implements Serializable {
+
   private static final long serialVersionUID = 0L;
 
   private String traceId;

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
@@ -117,11 +117,6 @@ public class ElasticsearchDependenciesJob {
       return this;
     }
 
-    public Builder properties(Map<String,String> properties){
-      sparkProperties.putAll(properties);
-      return this;
-    }
-
     public ElasticsearchDependenciesJob build() {
       return new ElasticsearchDependenciesJob(this);
     }
@@ -173,8 +168,8 @@ public class ElasticsearchDependenciesJob {
     return prefix != null ? String.format("%s-", prefix) : "";
   }
 
-  public void run() {
-    run(indexDate("jaeger-span"), indexDate("jaeger-dependencies"));
+  public void run(String peerServiceTag) {
+    run(indexDate("jaeger-span"), indexDate("jaeger-dependencies") ,peerServiceTag);
   }
 
   String[] indexDate(String index) {
@@ -186,7 +181,7 @@ public class ElasticsearchDependenciesJob {
     return new String[]{String.format("%s-%s", index, date)};
   }
 
-  void run(String[] spanIndices, String[] depIndices) {
+  void run(String[] spanIndices, String[] depIndices,String peerServiceTag) {
     JavaSparkContext sc = new JavaSparkContext(conf);
     try {
       for (int i = 0; i < spanIndices.length; i++) {
@@ -196,7 +191,7 @@ public class ElasticsearchDependenciesJob {
         JavaPairRDD<String, Iterable<Span>> traces = JavaEsSpark.esJsonRDD(sc, spanIndex)
             .map(new ElasticTupleToSpan())
             .groupBy(Span::getTraceId);
-        List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces);
+        List<Dependency> dependencyLinks = DependenciesSparkHelper.derive(traces,peerServiceTag);
         store(sc, dependencyLinks, depIndex + "/dependencies");
         log.info("Done, {} dependency objects created", dependencyLinks.size());
         if (dependencyLinks.size() > 0) {
@@ -204,7 +199,6 @@ public class ElasticsearchDependenciesJob {
           break;
         }
       }
-
     } finally {
       sc.stop();
     }

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJob.java
@@ -117,6 +117,11 @@ public class ElasticsearchDependenciesJob {
       return this;
     }
 
+    public Builder properties(Map<String,String> properties){
+      sparkProperties.putAll(properties);
+      return this;
+    }
+
     public ElasticsearchDependenciesJob build() {
       return new ElasticsearchDependenciesJob(this);
     }

--- a/jaeger-spark-dependencies-elasticsearch/src/test/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/test/java/io/jaegertracing/spark/dependencies/elastic/ElasticsearchDependenciesJobTest.java
@@ -71,7 +71,7 @@ public class ElasticsearchDependenciesJobTest extends DependenciesTest {
         .nodes("http://" + jaegerElasticsearchEnvironment.getElasticsearchIPPort())
         .day(LocalDate.now())
         .build();
-    dependenciesJob.run();
+    dependenciesJob.run("peer.service");
   }
 
   @Override

--- a/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
+++ b/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
@@ -41,35 +41,26 @@ public final class DependenciesSparkJob {
   }
 
   private static void run(String storage, LocalDate localDate) throws UnsupportedEncodingException {
-
+    String peerServiceTag = System.getenv("PEER_SERVICE_TAG");
+    if (peerServiceTag == null){
+      peerServiceTag = "peer.service";
+    }
     String jarPath = pathToUberJar();
     if ("elasticsearch".equalsIgnoreCase(storage)) {
       ElasticsearchDependenciesJob.builder()
           .jars(jarPath)
           .day(localDate)
-          .properties(prepareJobProperties())
           .build()
-          .run();
+          .run(peerServiceTag);
     } else if ("cassandra".equalsIgnoreCase(storage)) {
       CassandraDependenciesJob.builder()
           .jars(jarPath)
           .day(localDate)
-          .properties(prepareJobProperties())
           .build()
-          .run();
+          .run(peerServiceTag);
     } else {
       throw new IllegalArgumentException("Unsupported storage: " + storage);
     }
-  }
-
-  static Map<String,String> prepareJobProperties(){
-    Map<String,String> properties = new HashMap<>();
-    // Key for naming external services as dependencies
-    String uninstrumentedKey = System.getenv("UNINSTRUMENTED_DEPENDENCIES_KEY");
-    if (uninstrumentedKey != null){
-      properties.put("jaeger.uninstrumented_key",uninstrumentedKey);
-    }
-    return properties;
   }
 
   static String pathToUberJar() throws UnsupportedEncodingException {


### PR DESCRIPTION
Resolves : https://github.com/jaegertracing/spark-dependencies/issues/28


With the peer.service tag is present, it creates 'pseudo-service' when the span :
* is a leaf (no children)
* is a client (span.kind = 'client')
* has the tag tag_key (as specified in commandline)

The 'pseudo-service' name is the value of the tag 'peer.service'.

The tag key can be overriden by env variable

Signed-off-by: Etienne Carriere <etienne.a.carriere@socgen.com>
