### PR TITLE
Add entry to passwd when missing in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,10 @@ COPY mvnw $APP_HOME
 WORKDIR $APP_HOME
 RUN ./mvnw package -Dlicense.skip=true -DskipTests && rm -rf ~/.m2
 
+COPY entrypoint.sh /
+
+RUN chgrp root /etc/passwd && chmod g+rw /etc/passwd
+USER 185
+
+ENTRYPOINT ["/entrypoint.sh"]
 CMD java ${JAVA_OPTS} -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Taken from https://github.com/radanalyticsio/openshift-spark/blob/2.4/modules/common/added/scripts/entrypoint#L50
+# OpenShift passes random UID and spark requires it to be present in /etc/passwd
+function patch_uid {
+    # Check whether there is a passwd entry for the container UID
+    myuid=$(id -u)
+    mygid=$(id -g)
+    uidentry=$(getent passwd $myuid)
+
+    # If there is no passwd entry for the container UID, attempt to create one
+    if [ -z "$uidentry" ] ; then
+        if [ -w /etc/passwd ] ; then
+            echo "$myuid:x:$myuid:$mygid:anonymous uid:${PWD}:/bin/false" >> /etc/passwd
+        else
+            echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
+        fi
+    fi
+}
+
+patch_uid
+
+exec  "$@"
+exit $?


### PR DESCRIPTION
Resolves https://github.com/jaegertracing/jaeger-operator/issues/405

OCP executes the container with random UID and spark requires that value to be present in `/etc/paswd`.

Related links: 
* https://stackoverflow.com/a/45202955/4158442
* https://stackoverflow.com/questions/41864985/hadoop-ioexception-failure-to-login
* https://github.com/radanalyticsio/openshift-spark/blob/2.4/modules/common/added/scripts/entrypoint#L50