### PR TITLE
Fix entrypoint when changing default command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,5 +34,5 @@ function patch_uid {
 
 patch_uid
 
-exec  "$@"
+exec $@
 exit $?


### PR DESCRIPTION
## Which problem is this PR solving?
When changing the cmd to ``java  -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar: not found`` the entrypoint fails.
````
/entrypoint.sh: exec: line 37: java  -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar: not found
````

## Short description of the changes
We dont want to execute the file consisting of all args with spaces in between but probably the first file in the argument chain.
