### PR TITLE
Spans for kinds "producer" and "consumer" should be resolved as a dependency

### DIFF
--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.spark.SparkEnv;
 import org.apache.spark.api.java.function.Function;
 
 /**
@@ -49,7 +48,7 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
     }
 
     @Override
-    public Iterable<Dependency> call(Iterable<Span> trace) throws Exception {
+    public Iterable<Dependency> call(Iterable<Span> trace) {
         Map<Long, Set<Span>> spanMap = new LinkedHashMap<>();
         Map<Long, Set<Span>> spanChildrenMap = new LinkedHashMap<>();
         for (Span span: trace) {
@@ -143,14 +142,14 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
         return dependencies;
     }
 
-    private Optional<Dependency> sharedSpanDependency(Set<Span> sharedSpans) {
+    protected Optional<Dependency> sharedSpanDependency(Set<Span> sharedSpans) {
         String clientService = null;
         String serverService = null;
         for (Span span: sharedSpans) {
             for (KeyValue tag: span.getTags()) {
-                if (Tags.SPAN_KIND_CLIENT.equals(tag.getValueString())) {
+                if (Tags.SPAN_KIND_CLIENT.equals(tag.getValueString()) || Tags.SPAN_KIND_CONSUMER.equals(tag.getValueString())) {
                     clientService = span.getProcess().getServiceName();
-                } else if (Tags.SPAN_KIND_SERVER.equals(tag.getValueString())) {
+                } else if (Tags.SPAN_KIND_SERVER.equals(tag.getValueString()) || Tags.SPAN_KIND_PRODUCER.equals(tag.getValueString())) {
                     serverService = span.getProcess().getServiceName();
                 }
 

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -147,9 +147,9 @@ public class SpansToDependencyLinks implements Function<Iterable<Span>, Iterable
         String serverService = null;
         for (Span span: sharedSpans) {
             for (KeyValue tag: span.getTags()) {
-                if (Tags.SPAN_KIND_CLIENT.equals(tag.getValueString()) || Tags.SPAN_KIND_CONSUMER.equals(tag.getValueString())) {
+                if (Tags.SPAN_KIND_CLIENT.equals(tag.getValueString()) || Tags.SPAN_KIND_PRODUCER.equals(tag.getValueString())) {
                     clientService = span.getProcess().getServiceName();
-                } else if (Tags.SPAN_KIND_SERVER.equals(tag.getValueString()) || Tags.SPAN_KIND_PRODUCER.equals(tag.getValueString())) {
+                } else if (Tags.SPAN_KIND_SERVER.equals(tag.getValueString()) || Tags.SPAN_KIND_CONSUMER.equals(tag.getValueString())) {
                     serverService = span.getProcess().getServiceName();
                 }
 

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Dependency.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/model/Dependency.java
@@ -85,4 +85,13 @@ public class Dependency implements Serializable {
     h *= 1000003;
     return h;
   }
+
+  @Override
+  public String toString() {
+    return "Dependency{" +
+            "parent='" + parent + '\'' +
+            ", child='" + child + '\'' +
+            ", callCount=" + callCount +
+            '}';
+  }
 }

--- a/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
+++ b/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.jaegertracing.spark.dependencies;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.jaegertracing.spark.dependencies.model.Dependency;
+import io.jaegertracing.spark.dependencies.model.KeyValue;
+import io.jaegertracing.spark.dependencies.model.Process;
+import io.jaegertracing.spark.dependencies.model.Span;
+import io.opentracing.tag.Tags;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+
+public class SpansToDependencyLinksTest {
+
+    @Test
+    public void shouldReturnDependencyWithClientAndServerSpans() {
+        SpansToDependencyLinks spansToDependencyLinks = new SpansToDependencyLinks("");
+        Set<Span> sharedSpans = new HashSet<>();
+        sharedSpans.add(createSpan("clientName", Tags.SPAN_KIND_CLIENT));
+        sharedSpans.add(createSpan("serverName", Tags.SPAN_KIND_SERVER));
+        Optional<Dependency> result = spansToDependencyLinks.sharedSpanDependency(sharedSpans);
+        assertTrue(result.isPresent());
+        assertEquals(new Dependency("clientName", "serverName"), result.get());
+    }
+
+    @Test
+    public void shouldReturnDependencyWithConsumerAndProducer() {
+        SpansToDependencyLinks spansToDependencyLinks = new SpansToDependencyLinks("");
+        Set<Span> sharedSpans = new HashSet<>();
+        sharedSpans.add(createSpan("consumerName", Tags.SPAN_KIND_CONSUMER));
+        sharedSpans.add(createSpan("producerName", Tags.SPAN_KIND_PRODUCER));
+        Optional<Dependency> result = spansToDependencyLinks.sharedSpanDependency(sharedSpans);
+        assertTrue(result.isPresent());
+        assertEquals(new Dependency("consumerName", "producerName"), result.get());
+    }
+
+    @Test
+    public void shouldReturnEmptyDependencyForSpansWithoutSpanKindDefinition() {
+        SpansToDependencyLinks spansToDependencyLinks = new SpansToDependencyLinks("");
+        Set<Span> sharedSpans = new HashSet<>();
+        sharedSpans.add(createSpan("consumerName", "tag"));
+        sharedSpans.add(createSpan("producerName", "tag"));
+        Optional<Dependency> result = spansToDependencyLinks.sharedSpanDependency(sharedSpans);
+        assertFalse(result.isPresent());
+    }
+
+    private Span createSpan(String serviceName, String tag) {
+        List<KeyValue> tags = new ArrayList<>();
+        KeyValue keyValue = new KeyValue();
+        keyValue.setKey("span.kind");
+        keyValue.setValueString(tag);
+        tags.add(keyValue);
+        Span span = new Span();
+        Process process = new Process();
+        process.setServiceName(serviceName);
+        span.setProcess(process);
+        span.setTags(tags);
+        return span;
+    }
+}

--- a/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
+++ b/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The Jaeger Authors
+ * Copyright 2017 The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
+++ b/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
@@ -50,7 +50,7 @@ public class SpansToDependencyLinksTest {
         sharedSpans.add(createSpan("producerName", Tags.SPAN_KIND_PRODUCER));
         Optional<Dependency> result = spansToDependencyLinks.sharedSpanDependency(sharedSpans);
         assertTrue(result.isPresent());
-        assertEquals(new Dependency("consumerName", "producerName"), result.get());
+        assertEquals(new Dependency("producerName", "consumerName"), result.get());
     }
 
     @Test


### PR DESCRIPTION

Signed-off-by: Uladzislau Kiva <knijaz@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-Spans with tags consumer and producer should be visible at DAG and Dependencies diagrams (https://github.com/jaegertracing/jaeger-ui/issues/451)

## Short description of the changes
- Additional check if SPAN_KIND_CONSUMER or SPAN_KIND_PRODUCER
