### PR TITLE
pin base JDK version to 8b232

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@
 # the License.
 #
 
-FROM openjdk:alpine
+FROM openjdk:8u232-jdk-slim-buster
+
+MAINTAINER Pavol Loffay <ploffay@redhat.com>
 
 MAINTAINER Pavol Loffay <ploffay@redhat.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ FROM openjdk:8u232-jdk-slim-buster
 
 MAINTAINER Pavol Loffay <ploffay@redhat.com>
 
-MAINTAINER Pavol Loffay <ploffay@redhat.com>
-
 ENV APP_HOME /app/
 
 COPY pom.xml $APP_HOME

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@
 
 # Taken from https://github.com/radanalyticsio/openshift-spark/blob/2.4/modules/common/added/scripts/entrypoint#L50
 # OpenShift passes random UID and spark requires it to be present in /etc/passwd
-function patch_uid {
+patch_uid() {
     # Check whether there is a passwd entry for the container UID
     myuid=$(id -u)
     mygid=$(id -g)


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- JDK version in the Docker image is unpinned in the docker, making the actual version to be same as the build machine's cache (8b171). That particular build is missing JVM support for running inside containers.

## Short description of the changes
- pin Docker image JDK to buster slim 8b232.
