### PR TITLE
Use openjdk 8 slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@
 # the License.
 #
 
-FROM openjdk:alpine
-
-MAINTAINER Pavol Loffay <ploffay@redhat.com>
+FROM openjdk:8-jdk-slim as builder
 
 ENV APP_HOME /app/
 
@@ -30,10 +28,17 @@ COPY mvnw $APP_HOME
 WORKDIR $APP_HOME
 RUN ./mvnw package -Dlicense.skip=true -DskipTests && rm -rf ~/.m2
 
+FROM openjdk:8-jre-slim
+MAINTAINER Pavol Loffay <ploffay@redhat.com>
+ENV APP_HOME /app/
+COPY --from=builder $APP_HOME/jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar $APP_HOME/
+
+WORKDIR $APP_HOME
+
 COPY entrypoint.sh /
 
 RUN chgrp root /etc/passwd && chmod g+rw /etc/passwd
 USER 185
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD java ${JAVA_OPTS} -jar jaeger-spark-dependencies/target/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar
+CMD java ${JAVA_OPTS} -jar $APP_HOME/jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,7 @@
 
 # Taken from https://github.com/radanalyticsio/openshift-spark/blob/2.4/modules/common/added/scripts/entrypoint#L50
 # OpenShift passes random UID and spark requires it to be present in /etc/passwd
-function patch_uid {
+patch_uid() {
     # Check whether there is a passwd entry for the container UID
     myuid=$(id -u)
     mygid=$(id -g)


### PR DESCRIPTION
Created based on https://github.com/jaegertracing/spark-dependencies/pull/80

The alpine image is not maintained anymore. They have changed to `version-alpine` however it gets updates less frequently than slim version.

cc) @mindw 

The image size was 210mb and now is 291mb. 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>

