### PR TITLE
Added functionality to dynamically determine date relative to current date

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following variables are common to all storage layers:
 
     * `SPARK_MASTER`: Spark master to submit the job to; Defaults to `local[*]`
     * `DATE`: Date in YYYY-mm-dd format. Denotes a day for which dependency links will be created.
+    * `DATE_MINUS_DAYS`: If `DATE` is not set or passed in, this value is subtracted from the current date to determine the day for which dependency links will be created.
 
 ### Cassandra
 Cassandra is used when `STORAGE=cassandra`.

--- a/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
+++ b/jaeger-spark-dependencies/src/main/java/io/jaegertracing/spark/dependencies/DependenciesSparkJob.java
@@ -18,6 +18,7 @@ import io.jaegertracing.spark.dependencies.elastic.ElasticsearchDependenciesJob;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,9 @@ public final class DependenciesSparkJob {
       date = parseZonedDateTime(args[0]);
     } else if (System.getenv("DATE") != null) {
       date = parseZonedDateTime(System.getenv("DATE"));
+    } else if (System.getenv("DATE_MINUS_DAYS") != null && System.getenv("DATE_MINUS_DAYS").trim() != "") {
+      long days = Long.parseLong(System.getenv("DATE_MINUS_DAYS"));
+      date = date.minusDays(days);
     }
 
     run(storage, date);


### PR DESCRIPTION
If DATE value is not set or passed in, DATE_MINUS_DAYS can be a valid
integer which is subtracted from the current day to determine which
index should be used for creating dependency links.

Signed-off-by: Lin Meyer <lin@linmeyer.net>


## Which problem is this PR solving?
- It is not possible to set the index date dynamically at runtime when using a Kubernetes CronJob

## Short description of the changes
- Optional environment variable `DATE_MINUS_DAYS` can be set, which is subtracted from the current date.  For example, `DATE_MINUS_DAYS=5`; Then at runtime: `date = today - 5days;`
