### PR TITLE
Add elasticsearch storage date format config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Elasticsearch is used when `STORAGE=elasticsearch`.
                              If your elasticsearch cluster's data nodes only listen on loopback ip, set this to true.
                              Defaults to false
     * `ES_INDEX_PREFIX`: index prefix of Jaeger indices. By default unset.
+    * `ES_INDEX_DATE_SEPARATOR`: index date separator of Jaeger indices. The default value is `-`. 
+                                 For example `.` will find index "jaeger-span-2020.11.25". 
     * `ES_TIME_RANGE`: How far in the past the job should look to for spans, the maximum and default is `24h`.
                        Any value accepted by [date-math](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math) can be used here, but the anchor is always `now`.
 


### PR DESCRIPTION
Signed-off-by: Chen Zhengwei <chenzhengwei@inspur.com>


<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves https://github.com/jaegertracing/jaeger/issues/1489
Jaeger can customize the es date format.

## Short description of the changes
- User can configure the date separator to change the date format.
- Default date formate is yyyy-MM-dd, it won't affect the old version.

Associated PR: https://github.com/jaegertracing/jaeger/pull/2637
