### PR TITLE
Bump Elasticsearch spark version to 8.2.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,3 +38,20 @@ jobs:
         run: ./mvnw clean install -DskipTests
       - name: test
         run: ELASTICSEARCH_VERSION=7.3.0 ./mvnw clean test -pl jaeger-spark-dependencies-elasticsearch
+
+  latest-jaeger-es8:
+    name: Latest Jaeger and ES8
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: '11'
+      # TODO remove once testcontainers are updated
+      - name: pull ryuk image
+        run: docker pull testcontainersofficial/ryuk:0.3.0
+      - name: compile
+        run: ./mvnw clean install -DskipTests
+      - name: test
+        run: ELASTICSEARCH_VERSION=8.3.1 ./mvnw clean test -pl jaeger-spark-dependencies-elasticsearch

--- a/jaeger-spark-dependencies-elasticsearch/pom.xml
+++ b/jaeger-spark-dependencies-elasticsearch/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-spark-20_${version.scala.binary}</artifactId>
-      <version>7.13.4</version>
+      <version>8.2.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Current version of elasticsearch-spark-20 jar is using a 7.x version and doesn't want to work with Elasticsearch 8.x.

## Which problem is this PR solving?
- Resolves #125

## Short description of the changes
- Bumping version of jar to make it also work with 8.x versions.
