### PR TITLE
Update dependencies with critical CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ COPY .mvn $APP_HOME/.mvn
 COPY mvnw $APP_HOME
 
 WORKDIR $APP_HOME
-RUN ./mvnw package -Dlicense.skip=true -DskipTests && rm -rf ~/.m2
+RUN ./mvnw package -Dlicense.skip=true -DskipTests
+RUN rm -rf ~/.m2
 
 FROM eclipse-temurin:11-jre
 MAINTAINER Pavol Loffay <ploffay@redhat.com>

--- a/jaeger-spark-dependencies-cassandra/pom.xml
+++ b/jaeger-spark-dependencies-cassandra/pom.xml
@@ -37,6 +37,12 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${version.scala.binary}</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/jaeger-spark-dependencies-elasticsearch/pom.xml
+++ b/jaeger-spark-dependencies-elasticsearch/pom.xml
@@ -30,12 +30,18 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>jaeger-spark-dependencies-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch-spark-20_${version.scala.binary}</artifactId>
-      <version>7.13.4</version>
+      <version>7.17.10</version>
     </dependency>
 
     <dependency>

--- a/jaeger-spark-dependencies-elasticsearch/src/test/java/io/jaegertracing/spark/dependencies/elastic/JaegerElasticsearchEnvironment.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/test/java/io/jaegertracing/spark/dependencies/elastic/JaegerElasticsearchEnvironment.java
@@ -48,7 +48,7 @@ public class JaegerElasticsearchEnvironment {
 
   public static String elasticsearchVersion() {
     String version = System.getProperty("elasticsearch.version", System.getenv("ELASTICSEARCH_VERSION"));
-    return version != null ? version : "5.6.9";
+    return version != null ? version : "7.17.10";
   }
 
   public void start(Map<String, String> jaegerEnvs, String jaegerVersion, String elasticsearchVersion) {

--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,18 @@
     <version.io.zipkin.brave-brave>4.6.0</version.io.zipkin.brave-brave>
     <version.io.zipkin.reporter-zipkin-sender-okhttp3>1.0.2</version.io.zipkin.reporter-zipkin-sender-okhttp3>
     <version.junit>4.13.2</version.junit>
-    <version.org.assertj>3.22.0</version.org.assertj>
-    <version.org.testcontainers>1.14.3</version.org.testcontainers>
+    <version.org.assertj>3.24.2</version.org.assertj>
+    <version.org.testcontainers>1.18.1</version.org.testcontainers>
     <version.com.squareup.okhttp3-okhttp>3.14.9</version.com.squareup.okhttp3-okhttp>
-    <version.org.awaitility-awaitility>4.1.1</version.org.awaitility-awaitility>
+    <version.org.awaitility-awaitility>4.2.0</version.org.awaitility-awaitility>
 
     <version.maven-license-plugin>3.0</version.maven-license-plugin>
-    <version.maven-compiler-plugin>3.6.1</version.maven-compiler-plugin>
-    <version.maven-install-plugin>2.5.2</version.maven-install-plugin>
-    <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
+    <version.maven-compiler-plugin>3.11.0</version.maven-compiler-plugin>
+    <version.maven-install-plugin>3.1.1</version.maven-install-plugin>
+    <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
     <version.maven-plugin>0.3.4</version.maven-plugin>
-    <version.maven-shade-plugin>3.1.0</version.maven-shade-plugin>
+    <version.maven-shade-plugin>3.3.0</version.maven-shade-plugin>
+    <version.jackson>2.15.3</version.jackson>
   </properties>
 
   <inceptionYear>2017</inceptionYear>
@@ -107,6 +108,22 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -114,6 +131,12 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
         <version>${version.org.testcontainers}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${version.jackson}</version>
       </dependency>
 
       <!-- Forcibly bump Commons Collection version to avoid CVE-2015-7501 -->
@@ -136,7 +159,44 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${version.scala.binary}</artifactId>
       <version>${version.org.apache.spark}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.module</groupId>
+          <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+    <!-- BEGIN dependecy override versions -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${version.jackson}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${version.jackson}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-scala_${version.scala.binary}</artifactId>
+      <version>${version.jackson}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+      <version>2.10.2</version>
+    </dependency>
+    <!-- END dependency override versions -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Which problem is this PR solving?
- Spark Dependencies job has dependencies towards Java libraries with critical CVE associated with them. This PR will update those dependencies
- The Spark Dependencies job does not work with OpenSearch with the given version of the ElasticSearch dependency. By upgrading the ElasticSearch depdency, this Spark job is able to use OpenSearch as the storage backend.

## Description of the changes
- Override the dependencies in the maven's pom files
- Update ElasticSearch Java library

## How was this change tested?
- We have created our custom docker build of this Spark job and ran it internally for a long time with OpenSearch as the storage.
- Also verified that our internal security scanner removed those critical CVEs from the deployment.
- The tests are failing in this repo so I was not able to run the tests (no new tests added)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
