### PR TITLE
Сache .m2 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY .mvn $APP_HOME/.mvn
 COPY mvnw $APP_HOME
 
 WORKDIR $APP_HOME
-RUN ./mvnw package -Dlicense.skip=true -DskipTests && rm -rf ~/.m2
+RUN --mount=type=cache,target=/root/.m2 ./mvnw package -Dlicense.skip=true -DskipTests
 
 FROM eclipse-temurin:11-jre
 MAINTAINER Pavol Loffay <ploffay@redhat.com>


### PR DESCRIPTION
Previously, every docker build downloaded Maven dependencies on every build. This enables reuse .m2 folder across builds which significantly improves the build times.

## Which problem is this PR solving?

Running `docker build .` takes time, and most of the time is spent on downloading Maven dependencies

## Description of the changes

Mount `/root/.m2` as a cache folder

## How was this change tested?

Modify `.java` file, run `docker build .`.
After the fix, the output does not contain "downloading ..." messages.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
