### PR TITLE
Reduce verbosity on GitHub CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: pull ryuk image
         run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: test
-        run: ./mvnw clean test
+        run: ./mvnw --batch-mode clean test
 
   latest-jaeger-es7:
     name: Latest Jaeger and ES7
@@ -35,9 +35,9 @@ jobs:
       - name: pull ryuk image
         run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: compile
-        run: ./mvnw clean install -DskipTests
+        run: ./mvnw --batch-mode clean install -DskipTests
       - name: test
-        run: ELASTICSEARCH_VERSION=7.3.0 ./mvnw clean test -pl jaeger-spark-dependencies-elasticsearch
+        run: ELASTICSEARCH_VERSION=7.3.0 ./mvnw --batch-mode clean test -pl jaeger-spark-dependencies-elasticsearch
 
   latest-jaeger-es8:
     name: Latest Jaeger and ES8
@@ -52,6 +52,6 @@ jobs:
       - name: pull ryuk image
         run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: compile
-        run: ./mvnw clean install -DskipTests
+        run: ./mvnw --batch-mode clean install -DskipTests
       - name: test
-        run: ELASTICSEARCH_VERSION=8.3.1 ./mvnw clean test -pl jaeger-spark-dependencies-elasticsearch
+        run: ELASTICSEARCH_VERSION=8.3.1 ./mvnw --batch-mode clean test -pl jaeger-spark-dependencies-elasticsearch


### PR DESCRIPTION
## Which problem is this PR solving?

This removes irrelevant progress lines from the CI output:

```
Progress (1): 2.8/15 kB
Progress (1): 5.5/15 kB
Progress (1): 8.3/15 kB
Progress (1): 11/15 kB
Progress (1): 14/15 kB
Progress (1): 15 kB
```

## Description of the changes
- 

## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
