### PR TITLE
Use Cassandra 4.1 in integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   latest-jaeger:
-    name: Latest Jaeger
+    name: Latest Jaeger and Cassandra 4.x
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
@@ -45,7 +45,7 @@ public class CassandraDependenciesJobTest extends DependenciesTest {
   @BeforeClass
   public static void beforeClass() {
     network = Network.newNetwork();
-    cassandra = new CassandraContainer("cassandra:3.11")
+    cassandra = new CassandraContainer("cassandra:4.1")
         .withNetwork(network)
         .withNetworkAliases("cassandra")
         .withExposedPorts(9042);


### PR DESCRIPTION
Current tests are failing, per https://github.com/jaegertracing/spark-dependencies/pull/142#issuecomment-2637369354