### PR TITLE
Pin Jaeger version in Cassandra test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,8 @@ jobs:
       - name: pull ryuk image
         run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: test
-        run: ./mvnw clean test
+        # pin Jaeger version temporarily to work around build failures
+        run: JAEGER_VERSION=1.52.0 ./mvnw clean test
 
   latest-jaeger-es7:
     name: Latest Jaeger and ES7


### PR DESCRIPTION
Cassandra tests started failing, as diagnosed by @vlsi in https://github.com/jaegertracing/spark-dependencies/pull/142#issuecomment-2637369354

possibly related to https://github.com/jaegertracing/jaeger/pull/5922

Temporarily pin Jaeger version in the test to before that pull request.