### PR TITLE
Keep classes from Cassandra Java Driver

### DIFF
--- a/jaeger-spark-dependencies/pom.xml
+++ b/jaeger-spark-dependencies/pom.xml
@@ -68,6 +68,13 @@
                   </includes>
                 </filter>
                 <filter>
+                  <!-- Keep classes from Cassandra Java Driver -->
+                  <artifact>com.datastax.oss:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>log4j:log4j</artifact>
                   <includes>
                     <include>org/apache/log4j/spi/LoggingEvent.class</include>


### PR DESCRIPTION
## Which problem is this PR solving?

```
Caused by: java.lang.IllegalArgumentException: Can't find class DefaultMetricsFactory (specified by advanced.metrics.factory.class)
	at com.datastax.oss.driver.internal.core.util.Reflection.resolveClass(Reflection.java:302)
	at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfig(Reflection.java:235)
	at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfig(Reflection.java:110)
	at com.datastax.oss.driver.internal.core.context.DefaultDriverContext.buildMetricsFactory(DefaultDriverContext.java:548)
```

## Description of the changes

Include all the classes from Cassandra Java Driver as it includes shaded dependencies.

## How was this change tested?

Note that both `jaeger-spark-dependencies-cassandra` and `jaeger-spark-dependencies-elasticsearch` test **unshaded** artifacts, so they do not detect issues caused by shading.

Previously, local execution of `STORAGE=cassandra CASSANDRA_USERNAME=cassandra CASSANDRA_PASSWORD=cassandra java -jar jaeger-spark-dependencies-0.0.1-SNAPSHOT.jar` reproduced `Can't find class DefaultMetricsFactory`

After the fix, the error is gone.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
