### PR TITLE
Add CassandraDependenciesDockerJobTest to verify container-based docker job execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,11 @@ jobs:
           context: .
           push: false
           tags: ghcr.io/jaegertracing/spark-dependencies/spark-dependencies
+      - name: compile
+        run: ./mvnw --batch-mode clean install -DskipTests
       - name: test
         # pin Jaeger version temporarily to work around build failures
-        run: JAEGER_VERSION=1.52.0 ./mvnw --batch-mode clean test
+        run: JAEGER_VERSION=1.52.0 ./mvnw --batch-mode test -pl jaeger-spark-dependencies-cassandra
 
   latest-jaeger-es7:
     name: Latest Jaeger and ES7
@@ -45,7 +47,7 @@ jobs:
       - name: compile
         run: ./mvnw --batch-mode clean install -DskipTests
       - name: test
-        run: ELASTICSEARCH_VERSION=7.3.0 ./mvnw --batch-mode clean test -pl jaeger-spark-dependencies-elasticsearch
+        run: ELASTICSEARCH_VERSION=7.3.0 ./mvnw --batch-mode test -pl jaeger-spark-dependencies-elasticsearch
 
   latest-jaeger-es8:
     name: Latest Jaeger and ES8
@@ -62,4 +64,4 @@ jobs:
       - name: compile
         run: ./mvnw --batch-mode clean install -DskipTests
       - name: test
-        run: ELASTICSEARCH_VERSION=8.3.1 ./mvnw --batch-mode clean test -pl jaeger-spark-dependencies-elasticsearch
+        run: ELASTICSEARCH_VERSION=8.3.1 ./mvnw --batch-mode test -pl jaeger-spark-dependencies-elasticsearch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,13 @@ jobs:
       # TODO remove once testcontainers are updated
       - name: pull ryuk image
         run: docker pull testcontainersofficial/ryuk:0.3.0
+      - name: Build docker image
+        uses: docker/build-push-action@v2.7.0
+        # We need the image for the tests
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/jaegertracing/spark-dependencies/spark-dependencies
       - name: test
         # pin Jaeger version temporarily to work around build failures
         run: JAEGER_VERSION=1.52.0 ./mvnw --batch-mode clean test

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY .mvn $APP_HOME/.mvn
 COPY mvnw $APP_HOME
 
 WORKDIR $APP_HOME
-RUN --mount=type=cache,target=/root/.m2 ./mvnw package -Dlicense.skip=true -DskipTests
+RUN --mount=type=cache,target=/root/.m2 ./mvnw package --batch-mode -Dlicense.skip=true -DskipTests
 
 FROM eclipse-temurin:11-jre
 MAINTAINER Pavol Loffay <ploffay@redhat.com>

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesDockerJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesDockerJobTest.java
@@ -31,6 +31,7 @@ public class CassandraDependenciesDockerJobTest extends CassandraDependenciesJob
 
   @Override
   protected void deriveDependencies() {
+    System.out.println("::group::🚧 🚧 🚧 CassandraDependenciesDockerJob logs");
     try (GenericContainer<?> sparkDependenciesJob = new GenericContainer<>(
             DockerImageName.parse("ghcr.io/jaegertracing/spark-dependencies/spark-dependencies:" + dependenciesJobTag()))
             .withNetwork(network)
@@ -46,6 +47,8 @@ public class CassandraDependenciesDockerJobTest extends CassandraDependenciesJob
       await("spark-dependencies-job execution")
               .atMost(3, TimeUnit.MINUTES)
               .until(() -> !sparkDependenciesJob.isRunning());
+    } finally {
+        System.out.println("::endgroup::");
     }
   }
 }

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesDockerJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesDockerJobTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.jaegertracing.spark.dependencies.cassandra;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+
+public class CassandraDependenciesDockerJobTest extends CassandraDependenciesJobTest {
+  private static String dependenciesJobTag() {
+      String tag = System.getenv("SPARK_DEPENDENCIES_JOB_TAG");
+      if (tag == null || tag.isEmpty()) {
+          return "latest";
+      }
+      return tag.trim();
+  }
+
+  @Override
+  protected void deriveDependencies() {
+    try (GenericContainer<?> sparkDependenciesJob = new GenericContainer<>(
+            DockerImageName.parse("ghcr.io/jaegertracing/spark-dependencies/spark-dependencies:" + dependenciesJobTag()))
+            .withNetwork(network)
+            .withLogConsumer(new LogToConsolePrinter("[spark-dependencies] "))
+            .withEnv("STORAGE", "cassandra")
+            .withEnv("CASSANDRA_KEYSPACE", "jaeger_v1_dc1")
+            .withEnv("CASSANDRA_CONTACT_POINTS", "cassandra") // This should be an address within the docker network
+            .withEnv("CASSANDRA_LOCAL_DC", cassandra.getLocalDatacenter())
+            .withEnv("CASSANDRA_USERNAME", cassandra.getUsername())
+            .withEnv("CASSANDRA_PASSWORD", cassandra.getPassword())
+            .dependsOn(cassandra, jaegerCassandraSchema);){
+      sparkDependenciesJob.start();
+      await("spark-dependencies-job execution")
+              .atMost(3, TimeUnit.MINUTES)
+              .until(() -> !sparkDependenciesJob.isRunning());
+    }
+  }
+}

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
@@ -116,14 +116,19 @@ public class CassandraDependenciesJobTest extends DependenciesTest {
 
   @Override
   protected void deriveDependencies() {
-    CassandraDependenciesJob.builder()
-        .contactPoints("localhost:" + cassandraPort)
-        .day(LocalDate.now())
-        .keyspace("jaeger_v1_dc1")
-        .username(cassandra.getUsername())
-        .password(cassandra.getPassword())
-        .build()
-        .run("peer.service");
+    System.out.println("::group::🚧 🚧 🚧 CassandraDependenciesJob logs");
+    try {
+      CassandraDependenciesJob.builder()
+          .contactPoints("localhost:" + cassandraPort)
+          .day(LocalDate.now())
+          .keyspace("jaeger_v1_dc1")
+          .username(cassandra.getUsername())
+          .password(cassandra.getPassword())
+          .build()
+          .run("peer.service");
+    } finally {
+      System.out.println("::endgroup::");
+    }
   }
 
   @Override

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraDependenciesJobTest.java
@@ -15,8 +15,7 @@ package io.jaegertracing.spark.dependencies.cassandra;
 
 import static org.awaitility.Awaitility.await;
 
-import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
 import io.jaegertracing.spark.dependencies.test.DependenciesTest;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -26,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.cassandra.CassandraContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -36,17 +35,17 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
  */
 public class CassandraDependenciesJobTest extends DependenciesTest {
 
-  private static Network network;
-  private static CassandraContainer cassandra;
-  private static GenericContainer jaegerCollector;
-  private static GenericContainer jaegerQuery;
-  private static GenericContainer jaegerCassandraSchema;
+  protected static Network network;
+  protected static CassandraContainer cassandra;
+  protected static GenericContainer jaegerCollector;
+  protected static GenericContainer jaegerQuery;
+  protected static GenericContainer jaegerCassandraSchema;
   private static int cassandraPort;
 
   @BeforeClass
   public static void beforeClass() {
     network = Network.newNetwork();
-    cassandra = new CassandraContainer<>("cassandra:4.1")
+    cassandra = new CassandraContainer("cassandra:4.1")
         .withNetwork(network)
         .withNetworkAliases("cassandra")
         .withExposedPorts(9042);
@@ -54,7 +53,7 @@ public class CassandraDependenciesJobTest extends DependenciesTest {
     cassandraPort = cassandra.getMappedPort(9042);
 
     jaegerCassandraSchema = new GenericContainer<>("jaegertracing/jaeger-cassandra-schema:" + jaegerVersion())
-        .withLogConsumer(frame -> System.out.print(frame.getUtf8String()))
+        .withLogConsumer(new LogToConsolePrinter("[jaeger-cassandra-schema] "))
         .withNetwork(network);
     jaegerCassandraSchema.start();
     /**
@@ -97,13 +96,16 @@ public class CassandraDependenciesJobTest extends DependenciesTest {
 
   @After
   public void after() {
-    try (Cluster cluster = cassandra.getCluster(); Session session = cluster.newSession()) {
+    try (CqlSession session = CqlSession.builder()
+            .addContactPoint(cassandra.getContactPoint())
+            .withLocalDatacenter(cassandra.getLocalDatacenter())
+            .build()) {
       session.execute("TRUNCATE jaeger_v1_dc1.traces");
       session.execute(String.format("TRUNCATE jaeger_v1_dc1.%s", dependenciesTable(session)));
     }
   }
 
-  private String dependenciesTable(Session session) {
+  private String dependenciesTable(CqlSession session) {
     try {
       session.execute("SELECT ts from jaeger_v1_dc1.dependencies_v2 limit 1;");
     } catch (Exception ex) {

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/LogToConsolePrinter.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/LogToConsolePrinter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.jaegertracing.spark.dependencies.cassandra;
+
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.util.function.Consumer;
+
+public final class LogToConsolePrinter implements Consumer<OutputFrame> {
+    private final String prefix;
+
+    public LogToConsolePrinter(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame) {
+        String message = outputFrame.getUtf8String();
+        if (!message.isEmpty()) {
+            System.out.print(prefix);
+            System.out.print(message);
+        }
+    }
+}

--- a/jaeger-spark-dependencies/pom.xml
+++ b/jaeger-spark-dependencies/pom.xml
@@ -68,6 +68,13 @@
                   </includes>
                 </filter>
                 <filter>
+                  <!-- Keep classes from Cassandra Java Driver -->
+                  <artifact>com.datastax.oss:*</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+                <filter>
                   <artifact>log4j:log4j</artifact>
                   <includes>
                     <include>org/apache/log4j/spi/LoggingEvent.class</include>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,13 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>cassandra</artifactId>
         <version>${version.org.testcontainers}</version>
+        <exclusions>
+          <exclusion>
+            <!-- We want Cassandra Java 4 driver rather than the one included with testcontainers-cassandra -->
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Which problem is this PR solving?

The PR adds a test to execute the job with a docker image.
It would catch regressions if the image is not workable

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
