### PR TITLE
ci(docker): Publish versioned, multiarch releases

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -3,27 +3,51 @@ name: "Publish Container Image"
 on:
   push:
     branches: [ main ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish in addition to `latest`"
+        required: true
+        type: string
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v4.2.2
 
-      - name: Read version
-        run: echo "VERSION=$(cat autoinstrumentation/java/version.txt)" >> $GITHUB_ENV
+      - name: Compute Tags
+        id: compute-tags
+        run: |
+          prefix="ghcr.io/jaegertracing/spark-dependencies/spark-dependencies"
+          tags="$prefix:latest"
+          
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            tags="$tags,$prefix:${{ inputs.tag }}"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            release=$(echo ${{ github.ref }} | sed 's/refs\/tags\///g')
+            tags="$tags,$prefix:$release"
+          fi
+
+          echo "Computed tags for publication: $tags"
+          echo "tags=$tags" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2.7.0
+        uses: docker/build-push-action@v6.15.0
         with:
           context: .
           push: true
-          tags: ghcr.io/jaegertracing/spark-dependencies/spark-dependencies
+          tags: ${{ steps.compute-tags.outputs.tags }}
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -1,8 +1,6 @@
 name: "Publish Container Image"
 
 on:
-  push:
-    branches: [ main ]
   release:
     types: [ published ]
   workflow_dispatch:

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <version.io.zipkin.reporter-zipkin-sender-okhttp3>1.0.2</version.io.zipkin.reporter-zipkin-sender-okhttp3>
     <version.junit>4.13.2</version.junit>
     <version.org.assertj>3.24.2</version.org.assertj>
-    <version.org.testcontainers>1.20.4</version.org.testcontainers>
+    <version.org.testcontainers>1.20.6</version.org.testcontainers>
     <version.com.squareup.okhttp3-okhttp>3.14.9</version.com.squareup.okhttp3-okhttp>
     <version.org.awaitility-awaitility>4.2.0</version.org.awaitility-awaitility>
 


### PR DESCRIPTION
## Which problem is this PR solving?
This change to the publication process solves two outstanding issues:
- Resolves #124
- Resolves #64

As these two issues have been outstanding for some time, I opted not to create a new issue for these changes. I am happy to rectify that if need be.

## Description of the changes

### Versioned Publication
- The existing `publish-image.yml` GitHub workflow has been retooled to allow for tagged releases.
- The publication workflow now runs on two additional triggers:
    - `release`: Creating a release on the GitHub repo will publish an image with a matching tag
    - `workflow-dispatch`: The workflow can be run manually with an arbitrary tag string.
    - Both new triggers will also update the `latest` tag, preserving the current behavior.

This change presupposes no particular release / versioning strategy - it merely provides the foundation
for adopting one. At present, any deployment of this software is vulnerable to a breaking release of the 
code overriding the `latest` tag with no warning. This change provides the ability to create a long-lived 
image publication that can be considered stable.

### ARM64
- The `publish-image.yml` workflow now publishes both `linux/amd64` and `linux/arm64` images.

### Tests
- The version of `testcontainers` has been updated to `v1.20.6` to fix a bug preventing tests passing on (at least) Apple M1 hardware.

## How was this change tested?
- Executed testing instructions listed in `README.md`
- GitHub workflow behavior was tested on a private testbed repository to ensure correct dispatch behavior and tag computation. 
- The `linux/arm64` variant of the image builds and tests well on Apple M1 hardware. 
    - Testing on other ARM-based chips remains outstanding.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`

