### PR TITLE
Handle null references from Jaeger v2 spans in Elasticsearch

### DIFF
--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
@@ -97,7 +97,7 @@ public class SpanDeserializer extends StdDeserializer<Span> {
     }
 
     JsonNode referencesNode = node.get("references");
-    if (referencesNode != null && !referencesNode.isNull()) {
+    if (referencesNode != null) {
         Reference[] referencesArr = objectMapper.treeToValue(referencesNode, Reference[].class);
         references.addAll(Arrays.asList(referencesArr));
     }

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
@@ -97,7 +97,7 @@ public class SpanDeserializer extends StdDeserializer<Span> {
     }
 
     JsonNode referencesNode = node.get("references");
-    if (referencesNode != null) {
+    if (!referencesNode.isNull()) {
         Reference[] referencesArr = objectMapper.treeToValue(referencesNode, Reference[].class);
         references.addAll(Arrays.asList(referencesArr));
     }

--- a/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
+++ b/jaeger-spark-dependencies-elasticsearch/src/main/java/io/jaegertracing/spark/dependencies/elastic/json/SpanDeserializer.java
@@ -96,8 +96,11 @@ public class SpanDeserializer extends StdDeserializer<Span> {
       references.add(reference);
     }
 
-    Reference[] referencesArr = objectMapper.treeToValue(node.get("references"), Reference[].class);
-    references.addAll(Arrays.asList(referencesArr));
+    JsonNode referencesNode = node.get("references");
+    if (referencesNode != null && !referencesNode.isNull()) {
+        Reference[] referencesArr = objectMapper.treeToValue(referencesNode, Reference[].class);
+        references.addAll(Arrays.asList(referencesArr));
+    }
 
     return references;
   }


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/spark-dependencies/issues/157

## Description of the changes
- Handle cases where the span's `references` are null ([as is the case in Jaeger v2](https://github.com/jaegertracing/jaeger/blob/461923b41ff10964d723e8578421710d0ef42c3f/internal/storage/v2/elasticsearch/tracestore/to_dbmodel.go#L208)) by treating it the same way as if it was an empty array (behaviour of jaeger v1)

## How was this change tested?
- Built and ran locally against spans collected from a mix of jaeger v1 and v2 collectors

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
