### PR TITLE
Upgrade the workflows to use newer GH Ubuntu runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   latest-jaeger:
     name: Latest Jaeger and Cassandra 4.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -34,7 +34,7 @@ jobs:
 
   latest-jaeger-es7:
     name: Latest Jaeger and ES7
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
@@ -51,7 +51,7 @@ jobs:
 
   latest-jaeger-es8:
     name: Latest Jaeger and ES8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2


### PR DESCRIPTION
Bumped the version to the next supported as per https://github.com/actions/runner-images/issues/11101

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/82e219e9-2fde-4e33-a54f-c9c7cadc383a" />

## Description of the changes
- Updated workflows using the `ubuntu-20.04` image label to `ubuntu-22.04`.

## How was this change tested?
- Successfully ran actions on forked repo (https://github.com/leisurepassgroup/spark-dependencies/actions/runs/16100894710)

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
