### PR TITLE
Remove pulling of testcontainersofficial/ryuk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      # TODO remove once testcontainers are updated
-      - name: pull ryuk image
-        run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: Build docker image
         uses: docker/build-push-action@v2.7.0
         # We need the image for the tests
@@ -43,9 +40,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      # TODO remove once testcontainers are updated
-      - name: pull ryuk image
-        run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: Build docker image
         uses: docker/build-push-action@v2.7.0
         # We need the image for the tests
@@ -71,9 +65,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      # TODO remove once testcontainers are updated
-      - name: pull ryuk image
-        run: docker pull testcontainersofficial/ryuk:0.3.0
       - name: Build docker image
         uses: docker/build-push-action@v2.7.0
         # We need the image for the tests
@@ -99,9 +90,6 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      # TODO remove once testcontainers are updated
-      - name: pull ryuk image
-        run: docker pull testcontainersofficial/ryuk:0.3.0
       # Build mega-jar (unified JAR with both Cassandra and Elasticsearch support)
       # While ES9 doesn't require the mega-jar, we build it here to ensure it's tested at least once in CI
       - name: Build docker image

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ buildNumber.properties
 !/.mvn/wrapper/maven-wrapper.jar
 
 .testcontainers-tmp-*
+.vscode/


### PR DESCRIPTION
`docker pull testcontainersofficial/ryuk:0.3.0` seemed to be a left-over from earlier setups.
