### PR TITLE
fix(deps): Bump Jackson to 2.21.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
     <version.maven-plugin>0.3.4</version.maven-plugin>
     <version.maven-shade-plugin>3.6.2</version.maven-shade-plugin>
-    <version.jackson>2.21.1</version.jackson>
+    <version.jackson>2.21.5</version.jackson>
     <version.hadoop.client>3.3.6</version.hadoop.client>
     <version.elasticsearch.spark>9.1.3</version.elasticsearch.spark>
   </properties>


### PR DESCRIPTION
## Summary
- Bump the `version.jackson` property in the root `pom.xml` from 2.21.1 to **2.21.5**.
- This is the minimum Jackson 2.21.x pin that closes **all 11** open Dependabot alerts (19–29). 2.21.4 is not enough: alerts 25, 26, and 28 require 2.21.5.
- Equivalent Dependabot PR: #251 (`jackson-databind` 2.21.1 → 2.21.5). This PR is submitted from a maintainer fork so the same pin can land with a DCO-signed commit.

Closes:
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/19 — GHSA-rcqc-6cw3-h962 / CVE-2026-54518 (`@JsonView` bypass for unwrapped creator parameters)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/20 — GHSA-9fxm-vc8v-hj55 / CVE-2026-54516 (renamed `@JsonIgnore`'d setters)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/21 — GHSA-5hh8-q8hv-fr38 / CVE-2026-54517 (`@JsonView` bypass for setterless creator properties)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/22 — GHSA-j3rv-43j4-c7qm / CVE-2026-54512 (PolymorphicTypeValidator bypass via generic type parameters)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/23 — GHSA-rmj7-2vxq-3g9f / CVE-2026-54513 (array subtype allowlist bypass)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/24 — GHSA-hgj6-7826-r7m5 / CVE-2026-54514 (InetSocketAddress deserialization / SSRF)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/25 — GHSA-5jmj-h7xm-6q6v / CVE-2026-54515 (case-insensitive `@JsonIgnoreProperties` bypass; **needs 2.21.5**)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/26 — GHSA-mhm7-754m-9p8w (`@JsonView` bypass for creator properties; **needs 2.21.5**)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/27 — GHSA-3pjw-73gf-8qr5 / CVE-2026-59888 (`@JsonIgnore` on Record properties)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/28 — GHSA-5gvw-p9qm-jgwh / CVE-2026-59889 (`@JsonView` bypassed for `@JsonUnwrapped` containers; **needs 2.21.5**)
- https://github.com/jaegertracing/spark-dependencies/security/dependabot/29 — GHSA-r7wm-3cxj-wff9 (`jackson-core` async parser `maxNumberLength` bypass)

Related: #251, #252 (jackson-core → 2.21.4 only; insufficient).

## Test plan
- [x] `./mvnw -q -DskipTests compile` (or equivalent) on this branch
- [ ] CI unit/compile jobs on the PR
- [ ] E2E is known-flaky across unrelated PRs; do not block this security pin on E2E if compile/unit tests pass

Made with [Cursor](https://cursor.com)