### PR TITLE
fix(deps): Bump AssertJ to 3.27.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <version.io.opentelemetry>1.57.0</version.io.opentelemetry>
     <version.io.opentelemetry.instrumentation>2.10.0</version.io.opentelemetry.instrumentation>
     <version.junit>4.13.2</version.junit>
-    <version.org.assertj>3.27.6</version.org.assertj>
+    <version.org.assertj>3.27.7</version.org.assertj>
     <version.org.testcontainers>1.21.4</version.org.testcontainers>
     <version.com.squareup.okhttp3-okhttp>4.12.0</version.com.squareup.okhttp3-okhttp>
     <version.org.awaitility-awaitility>4.3.0</version.org.awaitility-awaitility>


### PR DESCRIPTION
## Summary
- Bump the `version.org.assertj` property in the root `pom.xml` from 3.27.6 to **3.27.7**.
- `org.assertj:assertj-core` is **test-scoped only**; this does not change the production runtime classpath.
- Closes Dependabot alert 15: [CVE-2026-24400](https://nvd.nist.gov/vuln/detail/CVE-2026-24400) / [GHSA-rqfh-9r24-8c9r](https://github.com/advisories/GHSA-rqfh-9r24-8c9r) (XXE in `isXmlEqualTo` / `XmlStringPrettyFormatter`).
- Alert: https://github.com/jaegertracing/spark-dependencies/security/dependabot/15
- Equivalent bot PRs: #225 (Renovate security) and #226 (Dependabot). This PR is submitted from a maintainer fork with a DCO-signed commit for the same pin.

## Test plan
- [x] `./mvnw -q -DskipTests compile` (or equivalent) on this branch
- [ ] CI unit/compile jobs on the PR
- [ ] E2E is known-flaky across unrelated PRs; do not block this test-only bump on E2E

Made with [Cursor](https://cursor.com)