### PR TITLE
fix(deps): Remove unused commons-lang 2.6 test dependency

### DIFF
--- a/jaeger-spark-dependencies-cassandra/pom.xml
+++ b/jaeger-spark-dependencies-cassandra/pom.xml
@@ -72,12 +72,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Summary
- Remove the unused **test-scoped** direct dependency `commons-lang:commons-lang:2.6` from `jaeger-spark-dependencies-cassandra/pom.xml`.
- Java sources in that module do not import `org.apache.commons.lang.*`, so this is not a lang3 migration.
- `./mvnw -pl jaeger-spark-dependencies-cassandra -am dependency:tree -Dincludes=commons-lang:commons-lang` before the change showed only the direct test pin (`commons-lang:commons-lang:jar:2.6:test`). After removal the same command prints **no** `commons-lang:commons-lang` nodes — Spark Cassandra Connector 3.4.1 pulls `commons-lang3`, not 2.x.
- Dependabot has **no patched 2.x** for [CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924) / [GHSA-j288-q9x7-2f5v](https://github.com/advisories/GHSA-j288-q9x7-2f5v). Removing the unused pin is the smallest change that closes the alert without a Spark upgrade.
- Alert: https://github.com/jaegertracing/spark-dependencies/security/dependabot/14

## Test plan
- [x] `./mvnw -pl jaeger-spark-dependencies-cassandra -am dependency:tree -Dincludes=commons-lang:commons-lang` (no 2.x after removal)
- [x] `./mvnw -q -DskipTests compile`
- [ ] CI unit/compile jobs on the PR
- [ ] E2E is known-flaky across unrelated PRs; do not block this unused-dep removal on E2E

Made with [Cursor](https://cursor.com)