### PR TITLE
fix: dedupe parent span refs so dependency counts are not doubled

### DIFF
--- a/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraSpan.java
+++ b/jaeger-spark-dependencies-cassandra/src/main/java/io/jaegertracing/spark/dependencies/cassandra/CassandraSpan.java
@@ -7,6 +7,7 @@ package io.jaegertracing.spark.dependencies.cassandra;
 import io.jaegertracing.spark.dependencies.model.Reference;
 import io.jaegertracing.spark.dependencies.model.Span;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -29,10 +30,17 @@ public class CassandraSpan extends Span {
 
   @Override
   public List<Reference> getRefs() {
-    ArrayList<Reference> references = new ArrayList<>(super.getRefs());
-    Reference legacyParent = new Reference();
-    legacyParent.setSpanId(parentId);
-    references.add(legacyParent);
-    return references;
+    List<Reference> existing = super.getRefs();
+    List<Reference> references = existing == null
+        ? new ArrayList<>()
+        : new ArrayList<>(existing);
+    if (parentId != null && parentId != 0L) {
+      Reference legacyParent = new Reference();
+      legacyParent.setSpanId(parentId);
+      if (!references.contains(legacyParent)) {
+        references.add(legacyParent);
+      }
+    }
+    return Collections.unmodifiableList(references);
   }
 }

--- a/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraSpanTest.java
+++ b/jaeger-spark-dependencies-cassandra/src/test/java/io/jaegertracing/spark/dependencies/cassandra/CassandraSpanTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) The Jaeger Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.jaegertracing.spark.dependencies.cassandra;
+
+import static org.junit.Assert.assertEquals;
+
+import io.jaegertracing.spark.dependencies.model.Reference;
+import java.util.Collections;
+import org.junit.Test;
+
+public class CassandraSpanTest {
+
+  @Test
+  public void shouldNotDuplicateParentWhenParentIdAlreadyInRefs() {
+    Reference childOf = new Reference();
+    childOf.setSpanId(1L);
+
+    CassandraSpan span = new CassandraSpan();
+    span.setParentId(1L);
+    span.setRefs(Collections.singletonList(childOf));
+
+    assertEquals(1, span.getRefs().size());
+    assertEquals(1L, span.getRefs().get(0).getSpanId().longValue());
+  }
+
+  @Test
+  public void shouldKeepLegacyParentIdWhenRefsEmpty() {
+    CassandraSpan span = new CassandraSpan();
+    span.setParentId(1L);
+
+    assertEquals(1, span.getRefs().size());
+    assertEquals(1L, span.getRefs().get(0).getSpanId().longValue());
+  }
+
+  @Test
+  public void shouldIgnoreNullAndZeroParentId() {
+    CassandraSpan span = new CassandraSpan();
+    span.setParentId(0L);
+
+    assertEquals(0, span.getRefs().size());
+  }
+}

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinks.java
@@ -49,13 +49,18 @@ public class SpansToDependencyLinks implements FlatMapFunction<Iterable<Span>, D
         Map<Long, Set<Span>> spanChildrenMap = new LinkedHashMap<>();
         for (Span span : uniqueSpans) {
             // Map of children
-            for (Reference ref: span.getRefs()){
-              Set <Span> children = spanChildrenMap.get(ref.getSpanId());
-              if (children == null){
-                children = new LinkedHashSet<>();
-                spanChildrenMap.put(ref.getSpanId(), children);
+            if (span.getRefs() != null) {
+              for (Reference ref: span.getRefs()){
+                if (ref == null || ref.getSpanId() == null) {
+                  continue;
+                }
+                Set <Span> children = spanChildrenMap.get(ref.getSpanId());
+                if (children == null){
+                  children = new LinkedHashSet<>();
+                  spanChildrenMap.put(ref.getSpanId(), children);
+                }
+                children.add(span);
               }
-              children.add(span);
             }
             // Map of parents
             Set<Span> sharedSpans = spanMap.get(span.getSpanId());
@@ -81,7 +86,12 @@ public class SpansToDependencyLinks implements FlatMapFunction<Iterable<Span>, D
                 continue;
             }
 
+            Set<Long> seenParentSpanIds = new LinkedHashSet<>();
             for (Reference reference: span.getRefs()) {
+                if (reference == null || reference.getSpanId() == null || reference.getSpanId() == 0L
+                    || !seenParentSpanIds.add(reference.getSpanId())) {
+                    continue;
+                }
                 Set<Span> parents = spanMap.get(reference.getSpanId());
                 if (parents != null) {
                     if (parents.size() > 1) {

--- a/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/json/SpanDeserializer.java
+++ b/jaeger-spark-dependencies-common/src/main/java/io/jaegertracing/spark/dependencies/json/SpanDeserializer.java
@@ -18,8 +18,10 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -89,21 +91,49 @@ public class SpanDeserializer extends StdDeserializer<Span> {
   }
 
   private List<Reference> deserializeReferences(JsonNode node) throws JsonProcessingException {
-    List<Reference> references = new ArrayList<>();
-    JsonNode parentSpanID = node.get("parentSpanID");
-    if (parentSpanID != null) {
-      BigInteger bigInteger = new BigInteger(parentSpanID.asText(), 16);
-      Reference reference = new Reference();
-      reference.setSpanId(bigInteger.longValue());
-      references.add(reference);
-    }
+    // Jaeger ES/OS v2 writes the parent both as parentSpanID and as a CHILD_OF entry in
+    // references (see jaegertracing/jaeger#8859). Counting both doubles call counts.
+    Set<Reference> references = new LinkedHashSet<>();
+    addParentSpanId(references, node.get("parentSpanID"));
 
     JsonNode referencesNode = node.get("references");
-    if (!referencesNode.isNull()) {
+    if (referencesNode != null && !referencesNode.isNull() && referencesNode.isArray()) {
       Reference[] referencesArr = objectMapper.treeToValue(referencesNode, Reference[].class);
-      references.addAll(Arrays.asList(referencesArr));
+      if (referencesArr != null) {
+        for (Reference reference : referencesArr) {
+          if (isUsableSpanId(reference == null ? null : reference.getSpanId())) {
+            references.add(reference);
+          }
+        }
+      }
     }
 
-    return references;
+    return new ArrayList<>(references);
+  }
+
+  private static void addParentSpanId(Set<Reference> references, JsonNode parentSpanID) {
+    if (parentSpanID == null || parentSpanID.isNull()) {
+      return;
+    }
+    String spanIdHex = parentSpanID.asText();
+    if (spanIdHex == null || spanIdHex.isEmpty() || isAllZeroHex(spanIdHex)) {
+      return;
+    }
+    Reference reference = new Reference();
+    reference.setSpanId(new BigInteger(spanIdHex, 16).longValue());
+    references.add(reference);
+  }
+
+  private static boolean isUsableSpanId(Long spanId) {
+    return spanId != null && spanId != 0L;
+  }
+
+  private static boolean isAllZeroHex(String spanIdHex) {
+    for (int i = 0; i < spanIdHex.length(); i++) {
+      if (spanIdHex.charAt(i) != '0') {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
+++ b/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/SpansToDependencyLinksTest.java
@@ -11,9 +11,11 @@ import static org.junit.Assert.assertTrue;
 import io.jaegertracing.spark.dependencies.model.Dependency;
 import io.jaegertracing.spark.dependencies.model.KeyValue;
 import io.jaegertracing.spark.dependencies.model.Process;
+import io.jaegertracing.spark.dependencies.model.Reference;
 import io.jaegertracing.spark.dependencies.model.Span;
 import io.opentracing.tag.Tags;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +54,36 @@ public class SpansToDependencyLinksTest {
         sharedSpans.add(createSpan("producerName", "tag"));
         Optional<Dependency> result = spansToDependencyLinks.sharedSpanDependency(sharedSpans);
         assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void shouldCountDuplicateParentReferencesOnce() throws Exception {
+        Span parent = spanWithId(1L, "S1");
+        Span child = spanWithId(2L, "S2");
+        Reference first = new Reference();
+        first.setSpanId(1L);
+        Reference duplicate = new Reference();
+        duplicate.setSpanId(1L);
+        child.setRefs(Arrays.asList(first, duplicate));
+
+        List<Dependency> dependencies = new ArrayList<>();
+        new SpansToDependencyLinks("").call(Arrays.asList(parent, child))
+            .forEachRemaining(dependencies::add);
+
+        assertEquals(1, dependencies.size());
+        assertEquals(new Dependency("S1", "S2"), dependencies.get(0));
+    }
+
+    private Span spanWithId(long spanId, String serviceName) {
+        Span span = new Span();
+        span.setTraceId("trace");
+        span.setSpanId(spanId);
+        span.setTags(new ArrayList<>());
+        span.setRefs(new ArrayList<>());
+        Process process = new Process();
+        process.setServiceName(serviceName);
+        span.setProcess(process);
+        return span;
     }
 
     private Span createSpan(String serviceName, String tag) {

--- a/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/json/SpanDeserializerTest.java
+++ b/jaeger-spark-dependencies-common/src/test/java/io/jaegertracing/spark/dependencies/json/SpanDeserializerTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) The Jaeger Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package io.jaegertracing.spark.dependencies.json;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jaegertracing.spark.dependencies.model.Span;
+import org.junit.Test;
+
+public class SpanDeserializerTest {
+
+  private final ObjectMapper objectMapper = JsonHelper.configure(new ObjectMapper());
+
+  @Test
+  public void shouldNotDuplicateParentWhenParentSpanIdAndReferencesBothPresent() throws Exception {
+    String json = "{"
+        + "\"traceID\":\"1\","
+        + "\"spanID\":\"2\","
+        + "\"parentSpanID\":\"1\","
+        + "\"startTime\":\"1\","
+        + "\"process\":{\"serviceName\":\"S2\"},"
+        + "\"tags\":[],"
+        + "\"references\":[{\"refType\":\"CHILD_OF\",\"traceID\":\"1\",\"spanID\":\"1\"}]"
+        + "}";
+
+    Span span = objectMapper.readValue(json, Span.class);
+
+    assertEquals(1, span.getRefs().size());
+    assertEquals(1L, span.getRefs().get(0).getSpanId().longValue());
+  }
+
+  @Test
+  public void shouldReadParentFromParentSpanIdWhenReferencesMissing() throws Exception {
+    String json = "{"
+        + "\"traceID\":\"1\","
+        + "\"spanID\":\"2\","
+        + "\"parentSpanID\":\"1\","
+        + "\"startTime\":\"1\","
+        + "\"process\":{\"serviceName\":\"S2\"},"
+        + "\"tags\":[]"
+        + "}";
+
+    Span span = objectMapper.readValue(json, Span.class);
+
+    assertEquals(1, span.getRefs().size());
+    assertEquals(1L, span.getRefs().get(0).getSpanId().longValue());
+  }
+
+  @Test
+  public void shouldIgnoreAllZeroParentSpanId() throws Exception {
+    String json = "{"
+        + "\"traceID\":\"1\","
+        + "\"spanID\":\"2\","
+        + "\"parentSpanID\":\"0000000000000000\","
+        + "\"startTime\":\"1\","
+        + "\"process\":{\"serviceName\":\"S1\"},"
+        + "\"tags\":[],"
+        + "\"references\":[]"
+        + "}";
+
+    Span span = objectMapper.readValue(json, Span.class);
+
+    assertEquals(0, span.getRefs().size());
+  }
+}


### PR DESCRIPTION
## Summary
- `jaeger:latest` writes the parent both as `parentSpanID`/`parent_id` and as a `CHILD_OF` reference (see jaegertracing/jaeger#8859). The Spark job counted both, so E2E `assertDependencies` saw ~2× call counts.
- Dedupe parent span ids in the ES/OS deserializer, Cassandra `parent_id` handling, and `SpansToDependencyLinks` so each parent is counted once.
- Adds unit tests for the deserializer, Cassandra span refs, and link derivation. E2E still needs CI (Docker was unavailable locally).

## Test plan
- [ ] Unit tests: `SpanDeserializerTest`, `CassandraSpanTest`, `SpansToDependencyLinksTest`
- [ ] `make e2e-cassandra`
- [ ] `make e2e-es7`
- [ ] `make e2e-es8`
- [ ] `make e2e-es9`
- [ ] Or wait for CI to run the integration suites


Made with [Cursor](https://cursor.com)