### PR TITLE
fix(deps): upgrade Hadoop client to 3.5.0 with dnsjava SPI shade fix

### DIFF
--- a/jaeger-spark-dependencies-cassandra/pom.xml
+++ b/jaeger-spark-dependencies-cassandra/pom.xml
@@ -103,6 +103,21 @@
                   </includes>
                 </filter>
                 <filter>
+                  <!-- Keep Hadoop's dnsjava classes, but do not register its JDK
+                       InetAddressResolverProvider. The provider lives only in the
+                       Multi-Release JAR (META-INF/versions/18); shade copies the SPI
+                       file without that class and Java 18+ fails at hostname lookup
+                       (HADOOP-19288, jaegertracing/spark-dependencies#217). -->
+                  <artifact>dnsjava:dnsjava</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
+                    <exclude>META-INF/versions/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>com.datastax.oss:*</artifact>
                   <includes>
                     <include>**</include>
@@ -182,6 +197,7 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/jaeger-spark-dependencies-elasticsearch/pom.xml
+++ b/jaeger-spark-dependencies-elasticsearch/pom.xml
@@ -88,6 +88,21 @@
                   </includes>
                 </filter>
                 <filter>
+                  <!-- Keep Hadoop's dnsjava classes, but do not register its JDK
+                       InetAddressResolverProvider. The provider lives only in the
+                       Multi-Release JAR (META-INF/versions/18); shade copies the SPI
+                       file without that class and Java 18+ fails at hostname lookup
+                       (HADOOP-19288, jaegertracing/spark-dependencies#217). -->
+                  <artifact>dnsjava:dnsjava</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
+                    <exclude>META-INF/versions/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>log4j:log4j</artifact>
                   <includes>
                     <include>org/apache/log4j/spi/LoggingEvent.class</include>
@@ -167,6 +182,7 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/jaeger-spark-dependencies-opensearch/pom.xml
+++ b/jaeger-spark-dependencies-opensearch/pom.xml
@@ -110,11 +110,24 @@
               <minimizeJar>false</minimizeJar>
               <filters>
                 <filter>
+                  <!-- Keep Hadoop's dnsjava classes, but do not register its JDK
+                       InetAddressResolverProvider. The provider lives only in the
+                       Multi-Release JAR (META-INF/versions/18); shade copies the SPI
+                       file without that class and Java 18+ fails at hostname lookup
+                       (HADOOP-19288, jaegertracing/spark-dependencies#217). -->
+                  <artifact>dnsjava:dnsjava</artifact>
+                  <excludes>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
+                    <exclude>META-INF/versions/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/jaeger-spark-dependencies/pom.xml
+++ b/jaeger-spark-dependencies/pom.xml
@@ -58,6 +58,21 @@
                   </includes>
                 </filter>
                 <filter>
+                  <!-- Keep Hadoop's dnsjava classes, but do not register its JDK
+                       InetAddressResolverProvider. The provider lives only in the
+                       Multi-Release JAR (META-INF/versions/18); shade copies the SPI
+                       file without that class and Java 18+ fails at hostname lookup
+                       (HADOOP-19288, jaegertracing/spark-dependencies#217). -->
+                  <artifact>dnsjava:dnsjava</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                  <excludes>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
+                    <exclude>META-INF/versions/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <!-- Keep classes from Cassandra Java Driver -->
                   <artifact>com.datastax.oss:*</artifact>
                   <includes>
@@ -148,6 +163,7 @@
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/services/java.net.spi.InetAddressResolverProvider</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,9 @@
     <version.maven-plugin>0.3.4</version.maven-plugin>
     <version.maven-shade-plugin>3.6.2</version.maven-shade-plugin>
     <version.jackson>2.21.5</version.jackson>
-    <version.hadoop.client>3.3.6</version.hadoop.client>
+    <!-- Hadoop 3.4+ pulls dnsjava 3.6, whose JDK InetAddressResolverProvider SPI
+         is unsafe to shade (HADOOP-19288). See maven-shade-plugin filters. -->
+    <version.hadoop.client>3.5.0</version.hadoop.client>
     <version.elasticsearch.spark>9.1.3</version.elasticsearch.spark>
   </properties>
 


### PR DESCRIPTION
## Summary
- Retry of #217 (`hadoop-client` 3.3.6 → **3.5.0**; 3.5.0 is still the latest 3.5.x on Maven Central).
- #217 was a version-only bump. E2E failed on every storage variant with:
  `java.util.ServiceConfigurationError: java.net.spi.InetAddressResolverProvider: Provider org.xbill.DNS.spi.DnsjavaInetAddressResolverProvider not found`
  (Log4j → `InetAddress.getLocalHost()`, reported by @yurishkuro).
- Hadoop 3.4+ pulls **dnsjava 3.6.1**, which registers a JDK `InetAddressResolverProvider` via SPI. The provider class lives only in the Multi-Release JAR (`META-INF/versions/18`). `maven-shade-plugin` copies the service file but not that class — the same failure Hadoop fixed in [HADOOP-19288](https://issues.apache.org/jira/browse/HADOOP-19288) for `hadoop-client-runtime`. This project shades `hadoop-client` (unshaded dnsjava) itself, so Hadoop's runtime shade fix does not apply.
- Shade filters now **keep dnsjava classes** (Hadoop may use them) but **omit** `META-INF/services/java.net.spi.InetAddressResolverProvider` and `META-INF/versions/**` from `dnsjava`, plus a catch-all SPI exclude. The JDK default resolver is used.

## Test plan
- [x] `./mvnw package -DskipTests` for cassandra, elasticsearch, opensearch variants
- [x] Shaded JARs do **not** contain `META-INF/services/java.net.spi.InetAddressResolverProvider` or `DnsjavaInetAddressResolverProvider` (dnsjava classes still present)
- [x] Smoke-run the Cassandra shaded JAR: past Log4j/`InetAddress.getLocalHost()` and Spark context start; fails later only because local Cassandra auth is unset (no `ServiceConfigurationError`)
- [x] `./mvnw test` on `jaeger-spark-dependencies-common` + `jaeger-spark-dependencies-test` (15 tests)
- [x] `CassandraSpanTest` (4 tests)
- [ ] **CI must prove Cassandra E2E** (`E2E Tests - cassandra`) and the other storage E2E jobs — Docker was not available locally

Made with [Cursor](https://cursor.com)