### PR TITLE
fix: replace daily OpenSearch dependency snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-.PHONY: e2e-cassandra e2e-es7 e2e-es8 e2e-es9 help
+.PHONY: e2e-cassandra e2e-es7 e2e-es8 e2e-es9 e2e-opensearch help
 
 help:
 	@echo "Available targets:"
@@ -11,6 +11,7 @@ help:
 	@echo "  e2e-es7        - Run Elasticsearch 7 integration tests"
 	@echo "  e2e-es8        - Run Elasticsearch 8 integration tests"
 	@echo "  e2e-es9        - Run Elasticsearch 9 integration tests"
+	@echo "  e2e-opensearch - Run OpenSearch integration tests"
 
 e2e-cassandra:
 	@echo "Building Docker image for Cassandra variant..."
@@ -63,3 +64,15 @@ e2e-es9:
 	./mvnw --batch-mode clean test -am \
 	  -pl jaeger-spark-dependencies-elasticsearch \
 	  -Dversion.elasticsearch.spark=9.1.3
+
+e2e-opensearch:
+	@echo "Building Docker image for OpenSearch variant..."
+	docker build \
+	  --build-arg VARIANT=opensearch \
+	  -t ghcr.io/jaegertracing/spark-dependencies/spark-dependencies:test-opensearch \
+	  .
+	@echo "Running OpenSearch integration tests..."
+	SPARK_DEPENDENCIES_JOB_IMAGE_TAG=test-opensearch \
+	OPENSEARCH_VERSION=2.11.1 \
+	./mvnw --batch-mode clean test -Dlicense.skip=true -am \
+	  -pl jaeger-spark-dependencies-opensearch

--- a/jaeger-spark-dependencies-opensearch/src/main/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesJob.java
+++ b/jaeger-spark-dependencies-opensearch/src/main/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesJob.java
@@ -25,6 +25,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -289,10 +290,6 @@ public class OpenSearchDependenciesJob {
   }
 
   private void store(JavaSparkContext javaSparkContext, List<Dependency> dependencyLinks, String resource) {
-    if (dependencyLinks.isEmpty()) {
-      return;
-    }
-
     String json;
     try {
       ObjectMapper objectMapper = new ObjectMapper();
@@ -301,19 +298,30 @@ public class OpenSearchDependenciesJob {
       throw new IllegalStateException("Could not serialize dependencies", e);
     }
 
-    JavaOpenSearchSpark.saveJsonToOpenSearch(javaSparkContext.parallelize(Collections.singletonList(json)), resource);
+    Map<String, String> writeConfiguration = new HashMap<>();
+    // Use the document ID from the JSON payload so retries replace the daily snapshot.
+    writeConfiguration.put("opensearch.mapping.id", "id");
+    writeConfiguration.put("opensearch.write.operation", "index");
+    JavaOpenSearchSpark.saveJsonToOpenSearch(
+        javaSparkContext.parallelize(Collections.singletonList(json)), resource, writeConfiguration);
   }
 
   /**
    * Helper class used to serialize dependencies to JSON.
    */
   public static final class OpenSearchDependencies {
+    private String id;
     private List<Dependency> dependencies;
     private ZonedDateTime ts;
 
     public OpenSearchDependencies(List<Dependency> dependencies, ZonedDateTime ts) {
+      this.id = documentId(ts);
       this.dependencies = dependencies;
       this.ts = ts;
+    }
+
+    public String getId() {
+      return id;
     }
 
     public List<Dependency> getDependencies() {
@@ -323,6 +331,10 @@ public class OpenSearchDependenciesJob {
     public String getTimestamp() {
       // Jaeger OS dependency storage uses RFC3339Nano for timestamp
       return ts.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
+    }
+
+    private static String documentId(ZonedDateTime timestamp) {
+      return "dependencies-" + timestamp.toLocalDate();
     }
   }
 

--- a/jaeger-spark-dependencies-opensearch/src/test/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesDockerJobTest.java
+++ b/jaeger-spark-dependencies-opensearch/src/test/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesDockerJobTest.java
@@ -33,7 +33,7 @@ public class OpenSearchDependenciesDockerJobTest extends OpenSearchDependenciesJ
     // indexDate() on it
     dependenciesJob = OpenSearchDependenciesJob.builder()
         .nodes("http://" + jaegerOpenSearchEnvironment.getOpenSearchIPPort())
-        .day(java.time.LocalDate.now())
+        .day(testDay)
         .build();
 
     try {
@@ -49,7 +49,7 @@ public class OpenSearchDependenciesDockerJobTest extends OpenSearchDependenciesJ
 
     // Use the same date as the test - format it as ISO-8601 date string for the
     // DATE env var
-    String dateStr = java.time.LocalDate.now().toString();
+    String dateStr = testDay.toString();
 
     System.out
         .println("Running Docker spark-dependencies job with DATE=" + dateStr + ", OS_NODES=http://opensearch:9200");

--- a/jaeger-spark-dependencies-opensearch/src/test/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesJobTest.java
+++ b/jaeger-spark-dependencies-opensearch/src/test/java/io/jaegertracing/spark/dependencies/opensearch/OpenSearchDependenciesJobTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -19,6 +20,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
 /**
@@ -28,6 +30,7 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 public class OpenSearchDependenciesJobTest extends DependenciesTest {
 
   protected OpenSearchDependenciesJob dependenciesJob;
+  protected final LocalDate testDay = LocalDate.now();
   static JaegerOpenSearchEnvironment jaegerOpenSearchEnvironment;
 
   @BeforeClass
@@ -72,11 +75,42 @@ public class OpenSearchDependenciesJobTest extends DependenciesTest {
     jaegerOpenSearchEnvironment.stop();
   }
 
+  @Test
+  public void shouldReplaceDailySnapshotWhenJobRunsTwice() throws Exception {
+    TracersGenerator.Tuple<Tracer, TracersGenerator.Flushable> parentTuple =
+        TracersGenerator.createJaeger("snapshot-parent", collectorUrl);
+    TracersGenerator.Tuple<Tracer, TracersGenerator.Flushable> childTuple =
+        TracersGenerator.createJaeger("snapshot-child", collectorUrl);
+
+    Span parent = parentTuple.getA().spanBuilder("parent").startSpan();
+    Span child = childTuple.getA().spanBuilder("child")
+        .setParent(io.opentelemetry.context.Context.current().with(parent))
+        .startSpan();
+    child.end();
+    parent.end();
+    parentTuple.getB().flush();
+    childTuple.getB().flush();
+
+    waitJaegerQueryContains("snapshot-parent", "parent");
+    waitJaegerQueryContains("snapshot-child", "child");
+
+    deriveDependencies();
+
+    Map<String, Map<String, Long>> expectedDependencies = new HashMap<>();
+    Map<String, Long> children = new HashMap<>();
+    children.put("snapshot-child", 1L);
+    expectedDependencies.put("snapshot-parent", children);
+    assertDependencies(expectedDependencies);
+
+    deriveDependencies();
+    assertDependencies(expectedDependencies);
+  }
+
   @Override
   protected void deriveDependencies() {
     dependenciesJob = OpenSearchDependenciesJob.builder()
         .nodes("http://" + jaegerOpenSearchEnvironment.getOpenSearchIPPort())
-        .day(LocalDate.now())
+        .day(testDay)
         .build();
     try {
       jaegerOpenSearchEnvironment.refresh();


### PR DESCRIPTION
## Which problem is this PR solving?

- Prevents duplicate and inflated dependency call counts when the Spark job runs hourly with a rolling time window.
- The job previously appended a new OpenSearch document on every run. Since `/api/dependencies` sums matching parent-child links, overlapping snapshots accumulated duplicate counts.
- Also prevents stale dependency data from remaining when a recomputation produces no dependency links.

## Description of the changes

- Add a deterministic daily document ID:
  `dependencies-YYYY-MM-DD`.
- Configure the OpenSearch Spark connector to use the serialized `id` field as the document ID.
- Use OpenSearch `index` write semantics so repeated hourly runs replace the same daily snapshot.
- Remove the early return for empty dependency results so an empty snapshot replaces stale data.
- Add `shouldReplaceDailySnapshotWhenJobRunsTwice`, which runs the job twice for the same day and verifies that dependency counts do not double.
- Add the `make e2e-opensearch` target for building the OpenSearch image and running the full OpenSearch integration suite.

## How was this change tested?

- Built the OpenSearch Maven module successfully:

  ```bash
  ./mvnw -pl jaeger-spark-dependencies-opensearch -am \
    -DskipTests -Dlicense.skip=true compile
  ```

- Built the OpenSearch JAR successfully using JDK 21.
- Built the OpenSearch Docker image successfully:

  ```text
  lmhinnel/jaegertracing/spark-dependencies:v0.7.2-opensearch
  ```

- Verified the resulting Docker image locally with `docker image inspect`.
- Ran the complete OpenSearch integration suite in a JDK 21 Maven container with Docker/Testcontainers access:
  - 4 `OpenSearchDependenciesJobTest` tests passed.
  - 4 `OpenSearchDependenciesDockerJobTest` tests passed.
  - 8 tests passed, with 0 failures and 0 errors.
- The host Maven run was blocked because only a JRE was installed, so the test run used a JDK 21 Maven container.

## Checklist

- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added a regression test for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [x] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
